### PR TITLE
Added kubernetes liveness and readiness probes

### DIFF
--- a/server/handlers/k8healthz.go
+++ b/server/handlers/k8healthz.go
@@ -1,0 +1,8 @@
+package handlers
+
+import "net/http"
+
+// Healthz is a liveness probe
+func HealthzHandler(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/server/handlers/k8sready.go
+++ b/server/handlers/k8sready.go
@@ -1,0 +1,17 @@
+package handlers
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+// ReadyzHandler is a ready probe that signals k8s to be able to retrieve traffic
+func ReadyzHandler(isReady *atomic.Value) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		if isReady == nil || !isReady.Load().(bool) {
+			http.Error(w, http.StatusText(http.StatusServiceUnavailable), http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}
+}


### PR DESCRIPTION
Kubernetes checks if a pod is ok and if it can retrieve traffic using probes. This commit add two routes to make a liveness probe and a readiness probe.

Added this two routes makes it possible to start mailpit also in a k8s cluster.
Kubernets can then use these two endpoints to monitor the application.