### PR TITLE
Correct typing mistake in README introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![CodeQL](https://github.com/axllent/mailpit/actions/workflows/codeql-analysis.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/axllent/mailpit)](https://goreportcard.com/report/github.com/axllent/mailpit)
 
-Mailpit is a multi-platform email testing tool / API for developers.
+Mailpit is a multi-platform email testing tool & API for developers.
 
 It acts as both an SMTP server, and provides a web interface to view all captured emails.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![CodeQL](https://github.com/axllent/mailpit/actions/workflows/codeql-analysis.yml/badge.svg)
 [![Go Report Card](https://goreportcard.com/badge/github.com/axllent/mailpit)](https://goreportcard.com/report/github.com/axllent/mailpit)
 
-Mailpit is a multi-platform email testing tool 7 API for developers.
+Mailpit is a multi-platform email testing tool / API for developers.
 
 It acts as both an SMTP server, and provides a web interface to view all captured emails.
 


### PR DESCRIPTION
I suppose instead of saying
```
Mailpit is a multi-platform email testing tool 7 API for developers.
```
it is supposed to say 
```
Mailpit is a multi-platform email testing tool / API for developers.
```