### PR TITLE
config: update listen regex to allow IPv6 addresses

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,10 +16,10 @@ import (
 
 var (
 	// SMTPListen to listen on <interface>:<port>
-	SMTPListen = "0.0.0.0:1025"
+	SMTPListen = "[::]:1025"
 
 	// HTTPListen to listen on <interface>:<port>
-	HTTPListen = "0.0.0.0:8025"
+	HTTPListen = "[::]:8025"
 
 	// DataFile for mail (optional)
 	DataFile string
@@ -106,7 +106,7 @@ func VerifyConfig() error {
 		DataFile = filepath.Join(DataFile, "mailpit.db")
 	}
 
-	re := regexp.MustCompile(`^[a-zA-Z0-9\.\-]{3,}:\d{2,}$`)
+	re := regexp.MustCompile(`^((\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})|(\[([\da-fA-F:])+\])):\d+$`)
 	if !re.MatchString(SMTPListen) {
 		return errors.New("SMTP bind should be in the format of <ip>:<port>")
 	}


### PR DESCRIPTION
The current regex for validating SMTP/HTTP listen addresses doesn't allow for IPv6 addresses.

This tweak changes the default to listen on both v4 and v6 by default, and updates the regexp so that it matches v4 and v6.