### PR TITLE
Feature: Recipient allowlist for SMTP relay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Mailpit is inspired by [MailHog](#why-rewrite-mailhog), but much, much faster.
 - Configurable automatic email pruning (default keeps the most recent 500 emails)
 - Email storage either in a temporary or persistent database ([see wiki](https://github.com/axllent/mailpit/wiki/Email-storage))
 - Fast SMTP processing & storing - approximately 70-100 emails per second depending on CPU, network speed & email size, easily handling tens of thousands of emails
-- SMTP relaying / message release - relay messages via a different SMTP server ([see wiki](https://github.com/axllent/mailpit/wiki/SMTP-relay))
+- SMTP relaying / message release - relay messages via a different SMTP server including a allowlist of accepted recipients ([see wiki](https://github.com/axllent/mailpit/wiki/SMTP-relay))
 - Optional SMTP with STARTTLS & SMTP authentication, including an "accept anything" mode ([see wiki](https://github.com/axllent/mailpit/wiki/SMTP-with-STARTTLS-and-authentication))
 - Optional HTTPS for web UI ([see wiki](https://github.com/axllent/mailpit/wiki/HTTPS))
 - Optional basic authentication for web UI ([see wiki](https://github.com/axllent/mailpit/wiki/Basic-authentication))

--- a/config/config.go
+++ b/config/config.go
@@ -111,15 +111,17 @@ type AutoTag struct {
 
 // SMTPRelayConfigStruct struct for parsing yaml & storing variables
 type smtpRelayConfigStruct struct {
-	Host          string `yaml:"host"`
-	Port          int    `yaml:"port"`
-	STARTTLS      bool   `yaml:"starttls"`
-	AllowInsecure bool   `yaml:"allow-insecure"`
-	Auth          string `yaml:"auth"`        // none, plain, cram-md5
-	Username      string `yaml:"username"`    // plain & cram-md5
-	Password      string `yaml:"password"`    // plain
-	Secret        string `yaml:"secret"`      // cram-md5
-	ReturnPath    string `yaml:"return-path"` // allows overriding the boune address
+	Host                     string `yaml:"host"`
+	Port                     int    `yaml:"port"`
+	STARTTLS                 bool   `yaml:"starttls"`
+	AllowInsecure            bool   `yaml:"allow-insecure"`
+	Auth                     string `yaml:"auth"`                // none, plain, cram-md5
+	Username                 string `yaml:"username"`            // plain & cram-md5
+	Password                 string `yaml:"password"`            // plain
+	Secret                   string `yaml:"secret"`              // cram-md5
+	ReturnPath               string `yaml:"return-path"`         // allows overriding the boune address
+	RecipientAllowlist       string `yaml:"recipient-allowlist"` // regex, if set needs to match for mails to be relayed
+	RecipientAllowlistRegexp *regexp.Regexp
 }
 
 // VerifyConfig wil do some basic checking
@@ -295,6 +297,18 @@ func parseRelayConfig(c string) error {
 	ReleaseEnabled = true
 
 	logger.Log().Infof("[smtp] enabling message relaying via %s:%d", SMTPRelayConfig.Host, SMTPRelayConfig.Port)
+
+	allowlistRegexp, err := regexp.Compile(SMTPRelayConfig.RecipientAllowlist)
+
+	if SMTPRelayConfig.RecipientAllowlist != "" {
+		if err != nil {
+			return fmt.Errorf("failed to compile recipient allowlist regexp: %e", err)
+		}
+
+		SMTPRelayConfig.RecipientAllowlistRegexp = allowlistRegexp
+		logger.Log().Infof("[smtp] recipient allowlist is active with the following regexp: %s", SMTPRelayConfig.RecipientAllowlist)
+
+	}
 
 	return nil
 }

--- a/server/apiv1/api.go
+++ b/server/apiv1/api.go
@@ -554,8 +554,15 @@ func ReleaseMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, to := range tos {
-		if _, err := mail.ParseAddress(to); err != nil {
+		address, err := mail.ParseAddress(to)
+
+		if err != nil {
 			httpError(w, "Invalid email address: "+to)
+			return
+		}
+
+		if config.SMTPRelayConfig.RecipientAllowlistRegexp != nil && !config.SMTPRelayConfig.RecipientAllowlistRegexp.MatchString(address.Address) {
+			httpError(w, "Mail address does not match allowlist: "+to)
 			return
 		}
 	}

--- a/server/apiv1/webui.go
+++ b/server/apiv1/webui.go
@@ -20,6 +20,8 @@ type webUIConfiguration struct {
 		SMTPServer string
 		// Enforced Return-Path (if set) for relay bounces
 		ReturnPath string
+		// Allowlist of accepted recipients
+		RecipientAllowlist string
 	}
 }
 
@@ -45,6 +47,7 @@ func WebUIConfig(w http.ResponseWriter, r *http.Request) {
 	if config.ReleaseEnabled {
 		conf.MessageRelay.SMTPServer = fmt.Sprintf("%s:%d", config.SMTPRelayConfig.Host, config.SMTPRelayConfig.Port)
 		conf.MessageRelay.ReturnPath = config.SMTPRelayConfig.ReturnPath
+		conf.MessageRelay.RecipientAllowlist = config.SMTPRelayConfig.RecipientAllowlist
 	}
 
 	bytes, _ := json.Marshal(conf)

--- a/server/smtpd/smtp.go
+++ b/server/smtpd/smtp.go
@@ -3,13 +3,45 @@ package smtpd
 import (
 	"crypto/tls"
 	"fmt"
-	"net/smtp"
-
 	"github.com/axllent/mailpit/config"
+	"github.com/axllent/mailpit/utils/logger"
+	"net/mail"
+	"net/smtp"
 )
+
+func allowedRecipients(to []string) []string {
+	if config.SMTPRelayConfig.RecipientAllowlistRegexp == nil {
+		return to
+	}
+
+	var ar []string
+
+	for _, recipient := range to {
+		address, err := mail.ParseAddress(recipient)
+
+		if err != nil {
+			logger.Log().Warnf("ignoring invalid email address: %s", recipient)
+			continue
+		}
+
+		if !config.SMTPRelayConfig.RecipientAllowlistRegexp.MatchString(address.Address) {
+			logger.Log().Debugf("[smtp] not allowed to relay to %s: does not match the allowlist %s", recipient, config.SMTPRelayConfig.RecipientAllowlist)
+		} else {
+			ar = append(ar, recipient)
+		}
+	}
+
+	return ar
+}
 
 // Send will connect to a pre-configured SMTP server and send a message to one or more recipients.
 func Send(from string, to []string, msg []byte) error {
+	recipients := allowedRecipients(to)
+
+	if len(recipients) == 0 {
+		return nil
+	}
+
 	addr := fmt.Sprintf("%s:%d", config.SMTPRelayConfig.Host, config.SMTPRelayConfig.Port)
 
 	c, err := smtp.Dial(addr)
@@ -48,7 +80,7 @@ func Send(from string, to []string, msg []byte) error {
 		return err
 	}
 
-	for _, addr := range to {
+	for _, addr := range recipients {
 		if err = c.Rcpt(addr); err != nil {
 			return err
 		}

--- a/server/ui-src/templates/MessageRelease.vue
+++ b/server/ui-src/templates/MessageRelease.vue
@@ -83,6 +83,11 @@ export default {
 						<div class="invalid-feedback">Invalid email address</div>
 					</div>
 				</div>
+                <div class="form-text text-center" v-if="relayConfig.MessageRelay.RecipientAllowlist != ''">
+                    Note: A recipient allowlist has been configured. Any mail address not matching it will be rejected.
+                    <br class="d-none d-md-inline">
+                    Configured allowlist: <b>{{ relayConfig.MessageRelay.RecipientAllowlist }}</b>
+                </div>
 				<div class="form-text text-center">
 					Note: For testing purposes, a unique Message-Id will be generated on send.
 					<br class="d-none d-md-inline">

--- a/storage/database.go
+++ b/storage/database.go
@@ -470,7 +470,7 @@ func GetMessage(id string) (*Message, error) {
 	messageID := strings.Trim(env.GetHeader("Message-ID"), "<>")
 
 	returnPath := strings.Trim(env.GetHeader("Return-Path"), "<>")
-	if returnPath == "" {
+	if returnPath == "" && from != nil {
 		returnPath = from.Address
 	}
 


### PR DESCRIPTION
Implements the recipient allowlist discussed in https://github.com/axllent/mailpit/issues/108

I've kept the UI part simple for now by just displaying the configured allowlist whenever it's active and denying the release on the backend. I could not reuse the regex on the frontend since golang and javascript have a different regex syntax:

<img width="818" alt="Screenshot 2023-05-04 at 23 50 15" src="https://user-images.githubusercontent.com/4993665/236338289-88fcb429-aa04-41da-aa4e-5be9b339e4dc.png">

<img width="816" alt="Screenshot 2023-05-04 at 23 51 00" src="https://user-images.githubusercontent.com/4993665/236338313-4044ee18-bb13-4bd2-aadd-5fdea6c32876.png">


