### PR TITLE
Fix: Add single dash arguments support to sendmail command

### DIFF
--- a/cmd/sendmail.go
+++ b/cmd/sendmail.go
@@ -30,7 +30,7 @@ func init() {
 	sendmailCmd.Flags().BoolVarP(&sendmail.UseB, "long-b", "b", false, "Handle SMTP commands on standard input (use as -bs)")
 	sendmailCmd.Flags().BoolVarP(&sendmail.UseS, "long-s", "s", false, "Handle SMTP commands on standard input (use as -bs)")
 	sendmailCmd.Flags().BoolP("verbose", "v", false, "Verbose mode (sends debug output to stderr)")
-	sendmailCmd.Flags().Bool("i", false, "Ignored")
-	sendmailCmd.Flags().Bool("o", false, "Ignored")
-	sendmailCmd.Flags().Bool("t", false, "Ignored")
+	sendmailCmd.Flags().BoolP("i", "i", false, "Ignored")
+	sendmailCmd.Flags().BoolP("o", "o", false, "Ignored")
+	sendmailCmd.Flags().BoolP("t", "t", false, "Ignored")
 }

--- a/sendmail/cmd/cmd.go
+++ b/sendmail/cmd/cmd.go
@@ -75,9 +75,9 @@ func Run() {
 	flag.BoolVarP(&UseB, "long-b", "b", false, "Handle SMTP commands on standard input (use as -bs)")
 	flag.BoolVarP(&UseS, "long-s", "s", false, "Handle SMTP commands on standard input (use as -bs)")
 	flag.BoolP("verbose", "v", false, "Ignored")
-	flag.Bool("i", false, "Ignored")
-	flag.Bool("o", false, "Ignored")
-	flag.Bool("t", false, "Ignored")
+	flag.BoolP("i", "i", false, "Ignored")
+	flag.BoolP("o", "o", false, "Ignored")
+	flag.BoolP("t", "t", false, "Ignored")
 
 	// set the default help
 	flag.Usage = func() {


### PR DESCRIPTION
mailpit sendmail -t was not working because of the single dash argument
parsing. This commit fixes it.