### PR TITLE
Update Messages.md

### DIFF
--- a/docs/apiv1/Messages.md
+++ b/docs/apiv1/Messages.md
@@ -137,7 +137,7 @@ The `read` status can be `true` or `false`.
 ```json
 {
   "ids": ["<ID>","<ID>"...],
-  "read": false
+  "status": false
 }
 ```
 


### PR DESCRIPTION
There is an inconsistency regarding the update status read and unread. The individual update uses "status", but for all update status requests, use "read".