### PR TITLE
Update mailbox count on web socket

### DIFF
--- a/server/ui-src/components/Notifications.vue
+++ b/server/ui-src/components/Notifications.vue
@@ -78,6 +78,7 @@ export default {
 				} else if (response.Type == "stats" && response.Data) {
 					// refresh mailbox stats
 					mailbox.total = response.Data.Total
+					mailbox.count = response.Data.Total
 					mailbox.unread = response.Data.Unread
 				}
 			}


### PR DESCRIPTION
I've noticed that when the mailbox is empty and it gets an email, the delete all button doesn't remove the disabled attribute because count isn't getting updated.

This should fix it so it'll be updated when new emails come in