### PR TITLE
Add @ as valid character for webroot

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -222,9 +222,9 @@ func VerifyConfig() error {
 		return errors.New("SMTP authentication requires TLS encryption, run with `--smtp-auth-allow-insecure` to allow insecure authentication")
 	}
 
-	validWebrootRe := regexp.MustCompile(`[^0-9a-zA-Z\/\-\_\.]`)
+	validWebrootRe := regexp.MustCompile(`[^0-9a-zA-Z\/\-\_\.@]`)
 	if validWebrootRe.MatchString(Webroot) {
-		return fmt.Errorf("Invalid characters in Webroot (%s). Valid chars include: [a-z A-Z 0-9 _ . - /]", Webroot)
+		return fmt.Errorf("Invalid characters in Webroot (%s). Valid chars include: [a-z A-Z 0-9 _ . - / @]", Webroot)
 	}
 
 	s := strings.TrimRight(path.Join("/", Webroot, "/"), "/") + "/"


### PR DESCRIPTION
Added @ as valid character for webroot. This allows the usage in Coder without a subdomain.

I am currently in the process of setting up a Coder instance and the way you can access apps in a workspace is either via subdomain or via subpath. This change allows the method of subpath.