### PR TITLE
Added send message API endpoint

### DIFF
--- a/server/apiv1/swagger.go
+++ b/server/apiv1/swagger.go
@@ -4,6 +4,121 @@ import "github.com/axllent/mailpit/internal/stats"
 
 // These structs are for the purpose of defining swagger HTTP parameters & responses
 
+// Send request
+// swagger:model sendMessageRequestBody
+type sendMessageRequestBody struct {
+	// Email+name pair to send the message from
+	//
+	// required: true
+	// example: {"email": "sender@example.com", "name": "Sender"}
+	From struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	} `json:"from"`
+
+	// Array of email+name pairs to send the message to
+	//
+	// required: true
+	// example: [{
+	// 	 "email": "user1@example.com",
+	// 	 "name": "user1",
+	// },
+	// {
+	//   "email": "user2@example.com"
+	// }],
+	To []struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	} `json:"to"`
+
+	// Array of email+name pairs to CC the message to
+	//
+	// required: true
+	// example: [{
+	// 	 "email": "user1@example.com",
+	// 	 "name": "user1",
+	// },
+	// {
+	//   "email": "user2@example.com"
+	// }],
+	CC []struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	} `json:"cc"`
+
+	// Array of email+name pairs to BCC the message to
+	//
+	// required: true
+	// example: [{
+	// 	 "email": "user1@example.com",
+	// 	 "name": "user1",
+	// },
+	// {
+	//   "email": "user2@example.com"
+	// }],
+	BCC []struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	} `json:"bcc"`
+
+	// Array of email+name pairs to add in the Reply-To header
+	//
+	// required: true
+	// example: [{
+	// 	 "email": "user1@example.com",
+	// 	 "name": "user1",
+	// },
+	// {
+	//   "email": "user2@example.com"
+	// }],
+	ReplyTo []struct {
+		Email string `json:"email"`
+		Name  string `json:"name"`
+	} `json:"replyTo"`
+
+	// Array of strings to add as tags
+	//
+	// required: false
+	// example: ["Tag 1", "Tag 2"]
+	Tags []string `json:"tags"`
+
+	// String of email subject
+	//
+	// required: true
+	// example: "Hello"
+	Subject string `json:"subject"`
+
+	// Map of headers
+	//
+	// required: false
+	// example: {"X-IP": "1.2.3.4"}
+	Headers map[string]string `json:"headers"`
+
+	// String of email text body
+	//
+	// required: true
+	// example: "Hello"
+	Text string `json:"text"`
+
+	// String of email HTML body
+	//
+	// required: true
+	// example: "<html><body>Hello</body></html>"
+	HTML string `json:"html"`
+
+	// Array of content+filename pairs to add as attachments
+	//
+	// required: false
+	// example: [{
+	// 	 "content": "VGhpcyBpcyBhIHBsYWluIHRleHQgYXRhY2htZW50Lg==",
+	// 	 "filename": "AttachedFile.txt",
+	// }],
+	Attachments []struct {
+		Content  string `json:"content"`
+		Filename string `json:"filename"`
+	} `json:"attachments"`
+}
+
 // Application information
 // swagger:response InfoResponse
 type infoResponse struct {

--- a/server/server.go
+++ b/server/server.go
@@ -117,6 +117,7 @@ func apiRoutes() *mux.Router {
 	r := mux.NewRouter()
 
 	// API V1
+	r.HandleFunc(config.Webroot+"api/v1/messages", middleWareFunc(apiv1.SendMessage)).Methods("POST")
 	r.HandleFunc(config.Webroot+"api/v1/messages", middleWareFunc(apiv1.GetMessages)).Methods("GET")
 	r.HandleFunc(config.Webroot+"api/v1/messages", middleWareFunc(apiv1.SetReadStatus)).Methods("PUT")
 	r.HandleFunc(config.Webroot+"api/v1/messages", middleWareFunc(apiv1.DeleteMessages)).Methods("DELETE")

--- a/server/smtpd/smtpd.go
+++ b/server/smtpd/smtpd.go
@@ -23,7 +23,7 @@ var (
 	DisableReverseDNS bool
 )
 
-func mailHandler(origin net.Addr, from string, to []string, data []byte) error {
+func MailHandler(origin net.Addr, from string, to []string, data []byte) error {
 	if !config.SMTPStrictRFCHeaders {
 		// replace all <CR><CR><LF> (\r\r\n) with <CR><LF> (\r\n)
 		// @see https://github.com/axllent/mailpit/issues/87 & https://github.com/axllent/mailpit/issues/153
@@ -207,7 +207,7 @@ func Listen() error {
 
 	logger.Log().Infof("[smtpd] starting on %s (%s)", config.SMTPListen, smtpType)
 
-	return listenAndServe(config.SMTPListen, mailHandler, authHandler)
+	return listenAndServe(config.SMTPListen, MailHandler, authHandler)
 }
 
 func listenAndServe(addr string, handler smtpd.Handler, authHandler smtpd.AuthHandler) error {


### PR DESCRIPTION
This adds an API endpoint for sending messages via HTTP, per feature request #278 

Example usage:

```
 curl -X POST http://localhost:8025/api/v1/messages \
     -H "Content-Type: application/json" \
     -d '{
          "from": { "email": "sender@example.com" },
          "to": [{
              "email": "recipient@example.com"
          }],
          "subject": "hello",
          "html": "<html><body>Hello</body></html>",
          "text": "Hello"
        }'
```

Note that in order to re-use code, I had to make the smtpd package `mailHandler` method public.

Open to suggestions for any changes but thought it would be nice to put something together to at least solve my immediate need.

Thanks for building mailpit!