### PR TITLE
mailpit-299 [fix] Adding dot stuffing for POP3

### DIFF
--- a/server/pop3/pop3.go
+++ b/server/pop3/pop3.go
@@ -239,7 +239,7 @@ func handleClient(conn net.Conn) {
 
 			size := len(raw)
 			sendData(conn, fmt.Sprintf("+OK %d octets", size))
-			sendData(conn, string(raw))
+			sendData(conn, strings.Replace(string(raw), "\n.", "\n..", -1))
 			sendData(conn, ".")
 
 		} else if cmd == "TOP" && state == TRANSACTION {


### PR DESCRIPTION
Fixes [issue 299](https://github.com/axllent/mailpit/issues/299) by adding dot stuffing to the POP3 server.

From the [POP3 spec](https://www.ietf.org/rfc/rfc1939.txt):

> When all lines of the response have been sent, a
final line is sent, consisting of a termination octet (decimal code
046, ".") and a CRLF pair. _If any line of the multi-line response
begins with the termination octet, the line is "byte-stuffed" by
pre-pending the termination octet to that line of the response._

In practice, this means that any message line starting with a dot must have an extra dot added at the start of the line. (The same technique is used in SMTP.)

Note: This is my first line of Golang. It does work, but I am not sure about its style.