### PR TITLE
Made container ready to run on OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ LABEL org.opencontainers.image.title="Mailpit" \
 
 COPY --from=builder /mailpit /mailpit
 
-RUN apk add --no-cache tzdata
+RUN apk add --no-cache tzdata \
+ && chgrp -R 0 /mailpit \
+ && chmod -R g=u /mailpit
 
 EXPOSE 1025/tcp 1110/tcp 8025/tcp
 


### PR DESCRIPTION
On OpenShift pods run as a random uid which is always member of gid 0. This unpredictability of the uid is a security feature of OpenShift. 

For a container to run successfully on OpenShift, it is necessary, that this random user has access to the files needed. 

To achieve that, one must set ownership of the files to gid 0: `chgrp -R 0 /mailpit`. The uid is irrelevant and can be set to whatever you want. 

Additionally the group file permissions have to set to the same as the user has: `chmod -R g=u /mailpit`.

I hope this helpful!

Thanks for you great work!

Cheers,
Thomas


