### PR TITLE
Changed POP3 size output to show compatible size

### DIFF
--- a/server/pop3/pop3.go
+++ b/server/pop3/pop3.go
@@ -193,10 +193,11 @@ func handleClient(conn net.Conn) {
 
 			// print all sizes
 			for row, m := range messages {
-				sendData(conn, fmt.Sprintf("%d %d", row+1, m.Size))
+				sendData(conn, fmt.Sprintf("%d %d", row+1, int64(m.Size))) // Convert Size to int64 when printing
 			}
 			// end
 			sendData(conn, ".")
+
 
 		} else if cmd == "UIDL" && state == TRANSACTION {
 			totalSize := float64(0)

--- a/server/pop3/pop3.go
+++ b/server/pop3/pop3.go
@@ -118,7 +118,7 @@ func handleClient(conn net.Conn) {
 	// First welcome the new connection
 	sendResponse(conn, "+OK Mailpit POP3 server")
 
-	timeoutDuration := 30 * time.Second
+	timeoutDuration := 600 * time.Second
 
 	for {
 		// POP3 server enforced a timeout of 30 seconds
@@ -197,7 +197,6 @@ func handleClient(conn net.Conn) {
 			}
 			// end
 			sendData(conn, ".")
-
 
 		} else if cmd == "UIDL" && state == TRANSACTION {
 			totalSize := float64(0)


### PR DESCRIPTION
This commit makes sure that LIST shows an RFC1939 compatible size

```
LIST
+OK 1 messages (5833 octets)
1 5833
```

Instead of 
```
LIST
+OK 5 messages (27300 octets)
1 %!d(float64=5461)
2 %!d(float64=5465)
3 %!d(float64=5350)
4 %!d(float64=5349)
5 %!d(float64=5675)
```

And fixes the `float64=5461` error of this issue https://github.com/axllent/mailpit/issues/311#issuecomment-2165453243