### PR TITLE
UI: Make multiple item selection work on macOS

### DIFF
--- a/server/ui-src/components/ListMessages.vue
+++ b/server/ui-src/components/ListMessages.vue
@@ -125,7 +125,8 @@ export default {
 				:id="message.ID"
 				class="row gx-1 message d-flex small list-group-item list-group-item-action border-start-0 border-end-0"
 				:class="message.Read ? 'read' : '', isSelected(message.ID) ? 'selected' : ''"
-				v-on:click.ctrl="toggleSelected($event, message.ID)" v-on:click.shift="selectRange($event, message.ID)">
+				@click.meta="toggleSelected($event, message.ID)" @click.ctrl="toggleSelected($event, message.ID)"
+				@click.shift="selectRange($event, message.ID)">
 				<div class="col-lg-3">
 					<div class="d-lg-none float-end text-muted text-nowrap small">
 						<i class="bi bi-paperclip h6 me-1" v-if="message.Attachments"></i>

--- a/server/ui-src/components/NavTags.vue
+++ b/server/ui-src/components/NavTags.vue
@@ -99,8 +99,8 @@ export default {
 			</ul>
 		</div>
 		<div class="list-group mt-1 mb-2">
-			<RouterLink v-for="tag in mailbox.tags" :to="toTagUrl(tag)" @click="hideNav"
-				v-on:click="pagination.start = 0" v-on:click.ctrl="toggleTag($event, tag)"
+			<RouterLink v-for="tag in mailbox.tags" :to="toTagUrl(tag)" @click.exact="hideNav"
+				v-on:click="pagination.start = 0" @click.meta="toggleTag($event, tag)" @click.ctrl="toggleTag($event, tag)"
 				:style="mailbox.showTagColors ? { borderLeftColor: colorHash(tag), borderLeftWidth: '4px' } : ''"
 				class="list-group-item list-group-item-action small px-2" :class="inSearch(tag) ? 'active' : ''">
 				<i class="bi bi-tag-fill" v-if="inSearch(tag)"></i>


### PR DESCRIPTION
The Feature to select multiple tags in the UI (#216) does not work properly on macOS. The problem is that on MacOS, the Ctrl key is typically used in conjunction with other keys, such as the Cmd key, to perform system-level functions. As a result, the Ctrl key is not always recognized as a modifier key in Vue.js applications.

This change introduces the usage of the mod key as a fallback, as there is currently no nice way to select between Ctrl/Mod based on the platform. See https://github.com/vuejs/vue/issues/4843 for discussion.