### PR TITLE
Feature: Add additional ignored flags to sendmail

### DIFF
--- a/sendmail/cmd/cmd.go
+++ b/sendmail/cmd/cmd.go
@@ -82,6 +82,9 @@ func Run() {
 	flag.BoolP("long-i", "i", false, "Ignored")
 	flag.BoolP("long-o", "o", false, "Ignored")
 	flag.BoolP("long-t", "t", false, "Ignored")
+	flag.StringP("from-name", "F", "", "Ignored")
+	flag.StringP("bits", "B", "", "Ignored")
+	flag.StringP("errors", "e", "", "Ignored")
 
 	// set the default help
 	flag.Usage = func() {


### PR DESCRIPTION
sendmail is sometimes used for sending the output of a crontab runtime.

those crontab might send 3 non-mapped options
- `-F` - name of the sender
- `-B` - configuration bits
- `-e` - delivery error behaviour

to not conflict with cron systems i mapped those flags so they don't prevent the e-mail from being sent to mailpit
