### PR TITLE
Make symlink detection more specific to contain "sendmail" in the name

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,10 +16,11 @@ func main() {
 	}
 
 	// running directly
-	if normalize(filepath.Base(exec)) == normalize(filepath.Base(os.Args[0])) {
+	if normalize(filepath.Base(exec)) == normalize(filepath.Base(os.Args[0])) ||
+	! strings.Contains(filepath.Base(os.Args[0]), "sendmail") {
 		cmd.Execute()
 	} else {
-		// symlinked
+		// symlinked as "*sendmail*"
 		sendmail.Run()
 	}
 }


### PR DESCRIPTION
I symlinked `mailpit_v1.21.4` -> `mailpit` as I tend to do in production.
That makes `mailpit` think it has been run as a 'sendmail` replacement. Did not go so well running it as a daemon...

This PR makes the symlink detection more strict. Hope this save time for others :joy: 

/DLange
