### PR TITLE
Fix: Message view not updating when deleting messages from search

### DIFF
--- a/internal/storage/search.go
+++ b/internal/storage/search.go
@@ -188,13 +188,6 @@ func DeleteSearch(search, timezone string) error {
 			if err != nil {
 				return err
 			}
-
-			for _, id := range ids {
-				d := struct {
-					ID string
-				}{ID: id}
-				websockets.Broadcast("delete", d)
-			}
 		}
 
 		err = tx.Commit()
@@ -208,6 +201,18 @@ func DeleteSearch(search, timezone string) error {
 		}
 
 		dbLastAction = time.Now()
+
+		// broadcast changes
+		if len(ids) > 200 {
+			websockets.Broadcast("prune", nil)
+		} else {
+			for _, id := range ids {
+				d := struct {
+					ID string
+				}{ID: id}
+				websockets.Broadcast("delete", d)
+			}
+		}
 
 		addDeletedSize(int64(deleteSize))
 

--- a/internal/storage/search.go
+++ b/internal/storage/search.go
@@ -13,6 +13,7 @@ import (
 	"github.com/araddon/dateparse"
 	"github.com/axllent/mailpit/internal/logger"
 	"github.com/axllent/mailpit/internal/tools"
+	"github.com/axllent/mailpit/server/websockets"
 	"github.com/leporo/sqlf"
 )
 
@@ -186,6 +187,13 @@ func DeleteSearch(search, timezone string) error {
 			_, err = tx.Exec(sqlDelete3, delIDs...)
 			if err != nil {
 				return err
+			}
+
+			for _, id := range ids {
+				d := struct {
+					ID string
+				}{ID: id}
+				websockets.Broadcast("delete", d)
 			}
 		}
 


### PR DESCRIPTION
When deleting messages from search with the API, the message view were never updated, while the message and unread count was.