### PR TITLE
WIP: Answering with SMTP error code, for testing

### DIFF
--- a/server/smtpd/lib.go
+++ b/server/smtpd/lib.go
@@ -405,6 +405,14 @@ loop:
 				break
 			}
 
+			errorMailFromRE = regexp.MustCompile(`_mailpit_smtp_reply_code_(\d\d\d)_after_mail_from@example\.com`)
+			match := errorMailFromRE.FindStringSubmatch(args)
+			if match {
+				// match[1] is meant to be the content of the first parentheses in the pattern:
+				s.writef(match[1] . " Answering with the STMP status code you requested in the MAIL FROM address")
+				break
+			}
+
 			match := mailFromRE.FindStringSubmatch(args)
 			if match == nil {
 				s.writef("501 5.5.4 Syntax error in parameters or arguments (invalid FROM parameter)")


### PR DESCRIPTION
Closes https://github.com/axllent/mailpit/issues/402

My knowledge of Go is (in your syntax): `nil`
But I'm sure you get the idea :-)

Based on your comment at https://github.com/axllent/mailpit/issues/402#issuecomment-2537240890
> the email would need to have already been processed in order to process the addresses

I'm *guessing* that maybe you aren't using the address given at `MAIL FROM` at all. If this is indeed the case, then it certainly would be easy to capture the contents of your `mailFromRE`s first parentheses into some variable.