### PR TITLE
Update lib.go: Changing `mailFromRE` regex

### DIFF
--- a/server/smtpd/lib.go
+++ b/server/smtpd/lib.go
@@ -28,7 +28,7 @@ var (
 	// Debug `true` enables verbose logging.
 	Debug      = false
 	rcptToRE   = regexp.MustCompile(`[Tt][Oo]:\s?<(.+)>`)
-	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]:\h?<([^>]*)>(\h(.*))?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
+	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]:\h?<([^>\v]*)>(\h(.*))?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
 	mailSizeRE = regexp.MustCompile(`[Ss][Ii][Zz][Ee]=(\d+)`)
 )
 

--- a/server/smtpd/lib.go
+++ b/server/smtpd/lib.go
@@ -28,7 +28,7 @@ var (
 	// Debug `true` enables verbose logging.
 	Debug      = false
 	rcptToRE   = regexp.MustCompile(`[Tt][Oo]:\s?<(.+)>`)
-	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]:\s?<(.*)>(\s(.*))?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
+	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]:\h?<([^>]*)>(\h(.*))?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
 	mailSizeRE = regexp.MustCompile(`[Ss][Ii][Zz][Ee]=(\d+)`)
 )
 


### PR DESCRIPTION
* First change: Strictly speaking, there's no whitespace allowed: https://datatracker.ietf.org/doc/html/rfc5321#section-3.3
  > Since it has been a common source of errors, it is worth noting that
   spaces are not permitted on either side of the colon following FROM
   in the MAIL command or TO in the RCPT command.  The syntax is exactly
   as given above.

  But I agree that it's OK to allow it, but I'd restrict it to *horizontal* whitespace.
* Second change: The pattern is still too liberal, since not all characters are allowed in an email address. But what's really important is that you can't accept an `>` or vertical whitespace here.
* Third change: certainly no vertical whitespace allowed here.

If you agree, I'd do the same for the other regex'es
