### PR TITLE
Update lib.go: Changing `mailFromRE` and `rcptToRE` regex

### DIFF
--- a/server/smtpd/lib.go
+++ b/server/smtpd/lib.go
@@ -27,8 +27,8 @@ import (
 var (
 	// Debug `true` enables verbose logging.
 	Debug      = false
-	rcptToRE   = regexp.MustCompile(`[Tt][Oo]: ?<([^>\v]+)>`)
-	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]: ?<([^>\v]+)>( (.*))?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
+	rcptToRE   = regexp.MustCompile(`[Tt][Oo]: ?<([^<>\v]+)>( |$)(.*)?`)
+	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]: ?<([^<>\v]+)>( |$)(.*)?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
 
 	// extract mail size from 'MAIL FROM' parameter
 	mailFromSizeRE = regexp.MustCompile(`(?U)(^| |,)[Ss][Ii][Zz][Ee]=(.*)($|,| )`)

--- a/server/smtpd/lib.go
+++ b/server/smtpd/lib.go
@@ -27,8 +27,8 @@ import (
 var (
 	// Debug `true` enables verbose logging.
 	Debug      = false
-	rcptToRE   = regexp.MustCompile(`[Tt][Oo]:\s?<(.+)>`)
-	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]:\s?<(.*)>(\s(.*))?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
+	rcptToRE   = regexp.MustCompile(`[Tt][Oo]: ?<([^>\v]+)>`)
+	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]: ?<([^>\v]+)>( (.*))?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
 
 	// extract mail size from 'MAIL FROM' parameter
 	mailFromSizeRE = regexp.MustCompile(`(?U)(^| |,)[Ss][Ii][Zz][Ee]=(.*)($|,| )`)

--- a/server/smtpd/lib.go
+++ b/server/smtpd/lib.go
@@ -28,7 +28,7 @@ var (
 	// Debug `true` enables verbose logging.
 	Debug      = false
 	rcptToRE   = regexp.MustCompile(`[Tt][Oo]: ?<([^<>\v]+)>( |$)(.*)?`)
-	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]: ?<([^<>\v]+)>( |$)(.*)?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
+	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]: ?<(|[^<>\v]+)>( |$)(.*)?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
 
 	// extract mail size from 'MAIL FROM' parameter
 	mailFromSizeRE = regexp.MustCompile(`(?U)(^| |,)[Ss][Ii][Zz][Ee]=(.*)($|,| )`)


### PR DESCRIPTION
I don't know how to rebase so I started from scratch ;-)

Most important change is `( |$)` in the middle, this removes the nested parentheses in the end; and therefore the entire regex is more readable I think (if a regex can be readable at all *g*...)

Anyway, this now fails on `foo>@example.com`.