### PR TITLE
Update smtpd.go: Adding case-insensitive flags to regex'es

### DIFF
--- a/internal/smtpd/smtpd.go
+++ b/internal/smtpd/smtpd.go
@@ -27,8 +27,8 @@ import (
 var (
 	// Debug `true` enables verbose logging.
 	Debug      = false
-	rcptToRE   = regexp.MustCompile(`[Tt][Oo]: ?<([^<>\v]+)>( |$)(.*)?`)
-	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]: ?<(|[^<>\v]+)>( |$)(.*)?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
+	rcptToRE   = regexp.MustCompile(`(?i)TO: ?<([^<>\v]+)>( |$)(.*)?`)
+	mailFromRE = regexp.MustCompile(`(?i)FROM: ?<(|[^<>\v]+)>( |$)(.*)?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
 
 	// extract mail size from 'MAIL FROM' parameter
 	mailFromSizeRE = regexp.MustCompile(`(?U)(^| |,)[Ss][Ii][Zz][Ee]=(.*)($|,| )`)

--- a/internal/smtpd/smtpd_test.go
+++ b/internal/smtpd/smtpd_test.go
@@ -84,8 +84,8 @@ func TestCmdHELO(t *testing.T) {
 
 	// Verify that HELO resets the current transaction state like RSET.
 	// RFC 2821 section 4.1.4 says EHLO should cause a reset, so verify that HELO does it too.
-	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
-	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "mail from:<sender@example.com>", "250") // Also testing case-insensitivity
+	cmdCode(t, conn, "rcpt to:<recipient@example.com>", "250")
 	cmdCode(t, conn, "HELO host.example.com", "250")
 	cmdCode(t, conn, "DATA", "503")
 


### PR DESCRIPTION
The syntax is taken from https://stackoverflow.com/a/15326471/1668200
Do you have tests for case-insensitivity?