### PR TITLE
First attempt at building linux/s390x Docker images.

### DIFF
--- a/.github/workflows/build-docker-edge.yml
+++ b/.github/workflows/build-docker-edge.yml
@@ -36,7 +36,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: .
-        platforms: linux/386,linux/amd64,linux/arm64
+        platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         build-args: |
           "VERSION=edge-${{ steps.short-sha.outputs.sha }}"
         push: true

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -30,7 +30,7 @@ jobs:
         password: ${{ github.token }}
 
     - name: Parse semver
-      id: semver_parser 
+      id: semver_parser
       uses: booxmedialtd/ws-action-parse-semver@v1.4.7
       with:
         input_string: '${{ github.ref_name }}'
@@ -40,7 +40,7 @@ jobs:
       uses: docker/build-push-action@v6
       with:
         context: .
-        platforms: linux/386,linux/amd64,linux/arm64
+        platforms: linux/386,linux/amd64,linux/arm64,linux/s390x
         build-args: |
           "VERSION=${{ github.ref_name }}"
         push: true

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         goos: [linux, windows, darwin]
-        goarch: ["386", amd64, arm, arm64]
+        goarch: ["386", amd64, arm, arm64, s390x]
         exclude:
           - goarch: "386"
             goos: darwin

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -20,6 +20,10 @@ jobs:
             goos: darwin
           - goarch: arm
             goos: windows
+          - goarch: s390x
+            goos: darwin
+          - goarch: s390x
+            goos: windows
     steps:
     - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Static binaries can always be found on the [releases](https://github.com/axllent
 
 ### Docker
 
-See [Docker instructions](https://mailpit.axllent.org/docs/install/docker/) for 386, amd64 & arm64 images.
+See [Docker instructions](https://mailpit.axllent.org/docs/install/docker/) for 386, amd64, arm64, and s390x images.
 
 
 ### Compile from source
@@ -104,6 +104,6 @@ Please refer to [the documentation](https://mailpit.axllent.org/docs/install/tes
 
 ### Configuring sendmail
 
-Mailpit's SMTP server (default on port 1025), so you will likely need to configure your sending application to deliver mail via that port. 
-A common MTA (Mail Transfer Agent) that delivers system emails to an SMTP server is `sendmail`, used by many applications, including PHP. 
+Mailpit's SMTP server (default on port 1025), so you will likely need to configure your sending application to deliver mail via that port.
+A common MTA (Mail Transfer Agent) that delivers system emails to an SMTP server is `sendmail`, used by many applications, including PHP.
 Mailpit can also act as substitute for sendmail. For instructions on how to set this up, please refer to the [sendmail documentation](https://mailpit.axllent.org/docs/install/sendmail/).

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,9 @@ i?86 | x86)
 aarch64 | arm64)
     OS_type='arm64'
     ;;
+s390x)
+    OS_type='s390x'
+    ;;
 *)
     echo 'OS type not supported'
     exit 2


### PR DESCRIPTION
## What

I'm opening this pull request as an attempt to update Mailpit to build and release Docker images for the [linux/s390x](https://en.wikipedia.org/wiki/IBM_System/390) platform.

## Why
There are use-cases where Docker images need to run on s390x systems.  Yes it is a discontinued ISA, but it is still widely used.  Many tools that build Docker images also include images for s390x.

I'm opening this pull request as an attempt to update Mailpit to build and release Docker images for that platform.

## How

Mailpit's Docker image are based on Alpine, which also build [Alpine for s390x](https://hub.docker.com/layers/library/golang/alpine/images/sha256-904b3eb3898b47e2fd84c626f6c8e5699e92f91c3433cedc837ed58c0c2698b2).  I've updated files that appear to be platform specific, or some platform specific verbiage.

I have not yet been able to test the Github Actions on the forked repo.  So I would greatly appreciate if you're able to.  No a big deal if not.  It would just take more time for me to set up the Github actions so they do not conflict in any way with the upstream repo.

I'd really appreciate if this could make it into proper Mailpit releases.  So I'm happy to accept feedback or further changes.
