### PR TITLE
Chore: Avoid shell in Docker health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ RUN apk upgrade --no-cache && apk add --no-cache tzdata
 
 EXPOSE 1025/tcp 1110/tcp 8025/tcp
 
-HEALTHCHECK --interval=15s --start-period=10s --start-interval=1s CMD /mailpit readyz
+HEALTHCHECK --interval=15s --start-period=10s --start-interval=1s CMD ["/mailpit", "readyz"]
 
 ENTRYPOINT ["/mailpit"]


### PR DESCRIPTION
Hardly significant, but... why not :)

https://docs.docker.com/reference/dockerfile/#healthcheck

Before (`docker image inspect axllent/mailpit | jq ".[0].Config.Healthcheck.Test"`):
```json
[
  "CMD-SHELL",
  "/mailpit readyz"
]
```

After:
```json
[
  "CMD",
  "/mailpit",
  "readyz"
]
```