### PR TITLE
Update busybox in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ COPY --from=builder /mailpit /mailpit
 
 RUN apk upgrade --no-cache && apk add --no-cache tzdata
 
+RUN apk add --no-cache busybox=1.37.0-r12 busybox-binsh=1.37.0-r12 ssl_client=1.37.0-r12
+
 EXPOSE 1025/tcp 1110/tcp 8025/tcp
 
 HEALTHCHECK --interval=15s --start-period=10s --start-interval=1s CMD ["/mailpit", "readyz"]


### PR DESCRIPTION
Hello, our DataDog Cloud Security Management scan found a critical vulnerability issue in the latest mailpit v1.24 image.

To mitigate this issue we are now building our own image, but I think its better to solve it here so we don't need to build and maintain our own image.

To solve this issue we need to update a couple of packages that are already in the base image. The vulnerability was found in Busybox. 

If you have any questions, please let me know.