### PR TITLE
Display unread count in app badge

### DIFF
--- a/server/ui-src/App.vue
+++ b/server/ui-src/App.vue
@@ -1,6 +1,7 @@
 <script>
 import CommonMixins from './mixins/CommonMixins'
 import Favicon from './components/Favicon.vue'
+import AppBadge from './components/AppBadge.vue'
 import Notifications from './components/Notifications.vue'
 import EditTags from './components/EditTags.vue'
 import { mailbox } from "./stores/mailbox"
@@ -10,6 +11,7 @@ export default {
 
 	components: {
 		Favicon,
+		AppBadge,
 		Notifications,
 		EditTags
 	},
@@ -40,6 +42,7 @@ export default {
 <template>
 	<RouterView />
 	<Favicon />
+	<AppBadge />
 	<Notifications />
 	<EditTags />
 </template>

--- a/server/ui-src/components/AppBadge.vue
+++ b/server/ui-src/components/AppBadge.vue
@@ -2,6 +2,14 @@
 import { mailbox } from '../stores/mailbox.js'
 
 export default {
+    data() {
+        return {
+            updating: false,
+            needsUpdate: false,
+            timeout: 500,
+        }
+    },
+
     computed: {
         mailboxUnread() {
             return mailbox.unread
@@ -10,23 +18,41 @@ export default {
 
     watch: {
         mailboxUnread: {
-            handler(newUnread) {
-                this.updateAppBadge(newUnread)
+            handler() {
+                if (this.updating) {
+                    this.needsUpdate = true
+                    return
+                }
+
+                this.scheduleUpdate()
             },
             immediate: true
         }
     },
 
     methods: {
-        updateAppBadge(unreadCount) {
+        scheduleUpdate() {
+            this.updating = true
+            this.needsUpdate = false
+
+            window.setTimeout(() => {
+                this.updateAppBadge()
+                this.updating = false
+
+                if (this.needsUpdate) {
+                    this.scheduleUpdate()
+                }
+            }, this.timeout)
+        },
+
+        updateAppBadge() {
             if (!('setAppBadge' in navigator)) {
                 return
             }
 
-            navigator.setAppBadge(unreadCount)
+            navigator.setAppBadge(this.mailboxUnread)
         }
     }
-
 }
 </script>
 

--- a/server/ui-src/components/AppBadge.vue
+++ b/server/ui-src/components/AppBadge.vue
@@ -1,0 +1,33 @@
+<script>
+import { mailbox } from '../stores/mailbox.js'
+
+export default {
+    computed: {
+        mailboxUnread() {
+            return mailbox.unread
+        }
+    },
+
+    watch: {
+        mailboxUnread: {
+            handler(newUnread) {
+                this.updateAppBadge(newUnread)
+            },
+            immediate: true
+        }
+    },
+
+    methods: {
+        updateAppBadge(unreadCount) {
+            if (!('setAppBadge' in navigator)) {
+                return
+            }
+
+            navigator.setAppBadge(unreadCount)
+        }
+    }
+
+}
+</script>
+
+<template></template>


### PR DESCRIPTION
Hi there! This PR makes use of `navigator.setAppBadge` to display a badge showing the number of unread messages when Mailpit is installed as a PWA (e.g. "Add to Dock..." in Safari or "Install page as app..." in Chrome).

<img width="288" alt="image" src="https://github.com/user-attachments/assets/00936b7e-9614-46ef-9a94-262219b22412" />
