### PR TITLE
Feature: replace To in header

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -304,6 +304,7 @@ func initConfigFromEnv() {
 	config.SMTPRelayConfig.Secret = os.Getenv("MP_SMTP_RELAY_SECRET")
 	config.SMTPRelayConfig.ReturnPath = os.Getenv("MP_SMTP_RELAY_RETURN_PATH")
 	config.SMTPRelayConfig.OverrideFrom = os.Getenv("MP_SMTP_RELAY_OVERRIDE_FROM")
+	config.SMTPRelayConfig.OverrideSendTo = getEnabledFromEnv("MP_SMTP_RELAY_OVERRIDE_SEND_TO")
 	config.SMTPRelayConfig.AllowedRecipients = os.Getenv("MP_SMTP_RELAY_ALLOWED_RECIPIENTS")
 	config.SMTPRelayConfig.BlockedRecipients = os.Getenv("MP_SMTP_RELAY_BLOCKED_RECIPIENTS")
 

--- a/config/config.go
+++ b/config/config.go
@@ -223,6 +223,7 @@ type SMTPRelayConfigStruct struct {
 	Secret                  string         `yaml:"secret"`             // cram-md5
 	ReturnPath              string         `yaml:"return-path"`        // allow overriding the bounce address
 	OverrideFrom            string         `yaml:"override-from"`      // allow overriding of the from address
+	OverrideSendTo          bool           `yaml:"override-send-to"`   // allow overriding of the from address
 	AllowedRecipients       string         `yaml:"allowed-recipients"` // regex, if set needs to match for mails to be relayed
 	AllowedRecipientsRegexp *regexp.Regexp // compiled regexp using AllowedRecipients
 	BlockedRecipients       string         `yaml:"blocked-recipients"` // regex, if set prevents relating to these addresses

--- a/internal/smtpd/relay.go
+++ b/internal/smtpd/relay.go
@@ -125,6 +125,13 @@ func Relay(from string, to []string, msg []byte) error {
 		from = config.SMTPRelayConfig.OverrideFrom
 	}
 
+    if config.SMTPRelayConfig.OverrideSendTo {
+		msg, err = tools.OverrideToHeader(msg, to)
+		if err != nil {
+			return fmt.Errorf("error overriding To header: %s", err.Error())
+		}
+	}
+
 	if err = c.Mail(from); err != nil {
 		return fmt.Errorf("error response to MAIL command: %s", err.Error())
 	}

--- a/server/ui-src/components/message/Release.vue
+++ b/server/ui-src/components/message/Release.vue
@@ -147,6 +147,9 @@ export default {
 							The <code>From</code> email address has been overridden by the relay configuration to
 							<code>{{ mailbox.uiConfig.MessageRelay.OverrideFrom }}</code>.
 						</li>
+                        <li v-if="mailbox.uiConfig.MessageRelay.OverrideSendTo != ''" class="form-text">
+                            The <code>To</code> email address(es) will be replaced with current <code>Send to</code>
+                        </li>
 						<li class="form-text">
 							SMTP delivery failures will bounce back to
 							<code v-if="mailbox.uiConfig.MessageRelay.ReturnPath != ''">


### PR DESCRIPTION
When you use the UI for releasing a message and you change the To address to another address because MP_SMTP_RELAY_ALLOWED_RECIPIENTS doesn't allow the current recipient (and we also does not allow this) you will send de mail to the new recipient with is defined in the UI and to the old recipient because our SMTP server read the message and the To: Header is not replaced.

Our SMTP Relay server is putting the new recipient into the BCC, which is a nice (unwanted) feature. and will send  the mail to both recipients