### PR TITLE
Send API allow separate auth

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,6 +112,8 @@ func init() {
 	rootCmd.Flags().StringVarP(&config.SMTPListen, "smtp", "s", config.SMTPListen, "SMTP bind interface and port")
 	rootCmd.Flags().StringVar(&config.SMTPAuthFile, "smtp-auth-file", config.SMTPAuthFile, "A password file for SMTP authentication")
 	rootCmd.Flags().BoolVar(&config.SMTPAuthAcceptAny, "smtp-auth-accept-any", config.SMTPAuthAcceptAny, "Accept any SMTP username and password, including none")
+	rootCmd.Flags().StringVar(&config.SendAPIAuthFile, "send-api-auth-file", config.SendAPIAuthFile, "A password file for Send API authentication")
+	rootCmd.Flags().BoolVar(&config.SendAPIAuthAcceptAny, "send-api-auth-accept-any", config.SendAPIAuthAcceptAny, "Accept any username and password for the Send API endpoint, including none")
 	rootCmd.Flags().StringVar(&config.SMTPTLSCert, "smtp-tls-cert", config.SMTPTLSCert, "TLS certificate for SMTP (STARTTLS) - requires smtp-tls-key")
 	rootCmd.Flags().StringVar(&config.SMTPTLSKey, "smtp-tls-key", config.SMTPTLSKey, "TLS key for SMTP (STARTTLS) - requires smtp-tls-cert")
 	rootCmd.Flags().BoolVar(&config.SMTPRequireSTARTTLS, "smtp-require-starttls", config.SMTPRequireSTARTTLS, "Require SMTP client use STARTTLS")
@@ -259,6 +261,13 @@ func initConfigFromEnv() {
 	}
 	if getEnabledFromEnv("MP_SMTP_AUTH_ACCEPT_ANY") {
 		config.SMTPAuthAcceptAny = true
+	}
+	config.SendAPIAuthFile = os.Getenv("MP_SEND_API_AUTH_FILE")
+	if err := auth.SetSendAPIAuth(os.Getenv("MP_SEND_API_AUTH")); err != nil {
+		logger.Log().Error(err.Error())
+	}
+	if getEnabledFromEnv("MP_SEND_API_AUTH_ACCEPT_ANY") {
+		config.SendAPIAuthAcceptAny = true
 	}
 	config.SMTPTLSCert = os.Getenv("MP_SMTP_TLS_CERT")
 	config.SMTPTLSKey = os.Getenv("MP_SMTP_TLS_KEY")

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -15,6 +15,8 @@ var (
 	SMTPCredentials *htpasswd.File
 	// POP3Credentials passwords
 	POP3Credentials *htpasswd.File
+	// SendAPICredentials passwords
+	SendAPICredentials *htpasswd.File
 )
 
 // SetUIAuth will set Basic Auth credentials required for the UI & API
@@ -67,6 +69,25 @@ func SetPOP3Auth(s string) error {
 	r := strings.NewReader(strings.Join(credentials, "\n"))
 
 	POP3Credentials, err = htpasswd.NewFromReader(r, htpasswd.DefaultSystems, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SetSendAPIAuth will set Send API credentials
+func SetSendAPIAuth(s string) error {
+	var err error
+
+	credentials := credentialsFromString(s)
+	if len(credentials) == 0 {
+		return nil
+	}
+
+	r := strings.NewReader(strings.Join(credentials, "\n"))
+
+	SendAPICredentials, err = htpasswd.NewFromReader(r, htpasswd.DefaultSystems, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Send API Allow Separate Authentication

This PR implements separate authentication controls for the Send API endpoint (`/api/v1/send`), allowing it to have different authentication requirements from the main UI and other API endpoints.

##  Features Added

**New Configuration Options:**
- `--send-api-auth-file` / `MP_SEND_API_AUTH_FILE`: Password file for Send API authentication
- `--send-api-auth-accept-any` / `MP_SEND_API_AUTH_ACCEPT_ANY`: Accept any credentials (or none) for Send API

**New Environment Variables:**
- `MP_SEND_API_AUTH`: Direct credential string for Send API authentication
- `MP_SEND_API_AUTH_FILE`: Path to Send API password file
- `MP_SEND_API_AUTH_ACCEPT_ANY`: Enable accept-any mode for Send API

##  Implementation Details

**Authentication Hierarchy:**
1. **Accept-Any Mode**: When `--send-api-auth-accept-any` is enabled, the Send API bypasses all authentication
2. **Dedicated Credentials**: When Send API credentials are configured, only those credentials are accepted
3. **Fallback to UI Auth**: When no Send API credentials are configured, falls back to existing UI authentication

**Code Changes:**
- Added `SendAPICredentials` to `internal/auth/auth.go`
- Added `SetSendAPIAuth()` function for credential management
- Implemented `sendAPIAuthMiddleware()` in `server/server.go` specifically for the Send API endpoint
- Added CLI flags in `cmd/root.go`

## Testing

Added `TestSendAPIAuthMiddleware()` covering:
- Accept-any mode bypassing all authentication
- Dedicated Send API credentials working correctly
- Rejection of incorrect Send API credentials
- Fallback to UI authentication when no Send API auth is configured
- Isolation, ensuring regular API endpoints remain unaffected by Send API auth settings

## Use Cases

1. **HTTP Send API testing**: Use `--send-api-auth-accept-any` to allow unauthenticated sending while keeping the UI protected, ideal for testing HTTP systems.
2. **Service-to-Service**: Use dedicated Send API credentials for automated systems while maintaining separate UI access
3. **Existing Setups**: No changes required - existing configurations continue to work as before


**To enable separate Send API auth:**
```bash
# Accept any credentials for Send API
mailpit --send-api-auth-accept-any

# Use dedicated credentials
mailpit --send-api-auth-file /path/to/sendapi.passwd

# Environment variables
export MP_SEND_API_AUTH="senduser:hashedpassword"
export MP_SEND_API_AUTH_ACCEPT_ANY=true
```

This implementation provides flexible authentication options for the Send API while maintaining backward compatibility and security isolation from other endpoints.