### PR TITLE
Support flexible 'from', 'to' and others address in SendRequest - Send API

### DIFF
--- a/server/apiv1/send_test.go
+++ b/server/apiv1/send_test.go
@@ -1,0 +1,93 @@
+package apiv1
+
+import (
+    "encoding/json"
+    "testing"
+)
+
+func TestEmailOrObjectUnmarshal(t *testing.T) {
+    var a EmailOrObject
+
+    // Test simple string
+    err := json.Unmarshal([]byte(`"user@example.com"`), &a)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if a.Name != "" || a.Email != "user@example.com" {
+        t.Fatalf("expected email only, got %+v", a)
+    }
+
+    // Test full object
+    err = json.Unmarshal([]byte(`{"name":"John Doe","email":"john@example.com"}`), &a)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if a.Name != "John Doe" || a.Email != "john@example.com" {
+        t.Fatalf("expected full struct, got %+v", a)
+    }
+}
+
+
+func TestEmailOrObjectListUnmarshal(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []EmailOrObject
+		wantErr  bool
+	}{
+		{
+			name:  "single email string",
+			input: `"bob@example.com"`,
+			expected: []EmailOrObject{
+				{Email: "bob@example.com"},
+			},
+		},
+		{
+			name:  "single object",
+			input: `{"name":"Alice","email":"alice@example.com"}`,
+			expected: []EmailOrObject{
+				{Name: "Alice", Email: "alice@example.com"},
+			},
+		},
+		{
+			name:  "array of strings",
+			input: `["bob@example.com", "jane@example.com"]`,
+			expected: []EmailOrObject{
+				{Email: "bob@example.com"},
+				{Email: "jane@example.com"},
+			},
+		},
+		{
+			name:  "array of objects",
+			input: `[{"name":"Alice","email":"alice@example.com"}, {"name":"Bob","email":"bob@example.com"}]`,
+			expected: []EmailOrObject{
+				{Name: "Alice", Email: "alice@example.com"},
+				{Name: "Bob", Email: "bob@example.com"},
+			},
+		},
+		{
+			name:    "invalid format",
+			input:   `12345`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result EmailOrObjectList
+			err := json.Unmarshal([]byte(tt.input), &result)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("unexpected error state: %v", err)
+			}
+			if !tt.wantErr && len(result) != len(tt.expected) {
+				t.Fatalf("expected %d items, got %d", len(tt.expected), len(result))
+			}
+			for i := range result {
+				if result[i] != tt.expected[i] {
+					t.Errorf("mismatch at index %d: got %+v, want %+v", i, result[i], tt.expected[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Send API address flexibility

Issues #512 

This PR implements flexible address for the Send API `/api/v1/send` to support different email address and lists fields format reposing on custom JSON desiralisation function of type :

```
type EmailOrObject struct {
	Name string
	Email string
}

type EmailOrObjectList []EmailOrObject
```

### Use Cases

The curent API need structured address with optionnal name and requeried email field, like:

```
{
    "from": { "email":'noreply@example.com" },
    "to": [ { "name": "John Do", "email": "john@example.com"}, { "email": "jane@example.com" }  ] ,
    "subject": "Test",
    "text": "Hello world"
}
```

This PR, give more flexibility on calling API
As exemple :
```
{
    "from": "noreply@example.com",
    "to": [ "john@example.com", { "email": "jane@example.com" }  ] ,
    "subject": "Test",
    "text": "Hello world"
}
```
or simple,
```
{
    "from": "noreply@example.com",
    "to": "mick@example.com",
    "subject": "Test",
    "text": "Hello world"
}
```

### Testing

Added `TestEmailOrObjectUnmarshal()` and `TestEmailOrObjectListUnmarshal()` covering deserialisations.

