### PR TITLE
Store username with messages, auto-tag, and UI display

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -372,6 +372,7 @@ func initConfigFromEnv() {
 	config.TagsConfig = os.Getenv("MP_TAGS_CONFIG")
 	tools.TagsTitleCase = getEnabledFromEnv("MP_TAGS_TITLE_CASE")
 	config.TagsDisable = os.Getenv("MP_TAGS_DISABLE")
+	config.TagsUsername = getEnabledFromEnv("MP_TAGS_USERNAME")
 
 	// Prometheus metrics
 	if len(os.Getenv("MP_ENABLE_PROMETHEUS")) > 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -158,6 +158,7 @@ func init() {
 	rootCmd.Flags().StringVar(&config.TagsConfig, "tags-config", config.TagsConfig, "Load tags filters from yaml configuration file")
 	rootCmd.Flags().BoolVar(&tools.TagsTitleCase, "tags-title-case", tools.TagsTitleCase, "TitleCase new tags generated from plus-addresses and X-Tags")
 	rootCmd.Flags().StringVar(&config.TagsDisable, "tags-disable", config.TagsDisable, "Disable auto-tagging, comma separated (eg: plus-addresses,x-tags)")
+	rootCmd.Flags().BoolVar(&config.TagsUsername, "tags-username", config.TagsUsername, "Auto-tag messages with the authenticated username")
 
 	// Prometheus metrics
 	rootCmd.Flags().StringVar(&config.PrometheusListen, "enable-prometheus", config.PrometheusListen, "Enable Prometheus metrics: true|false|<ip:port> (eg:'0.0.0.0:9090')")

--- a/config/config.go
+++ b/config/config.go
@@ -129,6 +129,9 @@ var (
 	// including x-tags & plus-addresses
 	TagsDisable string
 
+	// TagsUsername enables auto-tagging messages with the authenticated username
+	TagsUsername bool
+
 	// SMTPRelayConfigFile to parse a yaml file and store config of the relay SMTP server
 	SMTPRelayConfigFile string
 

--- a/internal/pop3/pop3_test.go
+++ b/internal/pop3/pop3_test.go
@@ -346,7 +346,7 @@ func insertEmailData(t *testing.T) {
 
 		bufBytes := buf.Bytes()
 
-		id, err := storage.Store(&bufBytes)
+		id, err := storage.Store(&bufBytes, nil)
 		if err != nil {
 			t.Log("error ", err)
 			t.Fail()

--- a/internal/smtpd/main.go
+++ b/internal/smtpd/main.go
@@ -28,12 +28,12 @@ var (
 )
 
 // MailHandler handles the incoming message to store in the database
-func mailHandler(origin net.Addr, from string, to []string, data []byte) (string, error) {
-	return SaveToDatabase(origin, from, to, data)
+func mailHandler(origin net.Addr, from string, to []string, data []byte, username *string) (string, error) {
+	return SaveToDatabase(origin, from, to, data, username)
 }
 
 // SaveToDatabase will attempt to save a message to the database
-func SaveToDatabase(origin net.Addr, from string, to []string, data []byte) (string, error) {
+func SaveToDatabase(origin net.Addr, from string, to []string, data []byte, username *string) (string, error) {
 	if !config.SMTPStrictRFCHeaders && bytes.Contains(data, []byte("\r\r\n")) {
 		// replace all <CR><CR><LF> (\r\r\n) with <CR><LF> (\r\n)
 		// @see https://github.com/axllent/mailpit/issues/87 & https://github.com/axllent/mailpit/issues/153
@@ -110,7 +110,7 @@ func SaveToDatabase(origin net.Addr, from string, to []string, data []byte) (str
 		logger.Log().Debugf("[smtpd] added missing addresses to Bcc header: %s", strings.Join(missingAddresses, ", "))
 	}
 
-	id, err := storage.Store(&data)
+	id, err := storage.Store(&data, username)
 	if err != nil {
 		logger.Log().Errorf("[db] error storing message: %s", err.Error())
 		return "", err

--- a/internal/storage/messages_test.go
+++ b/internal/storage/messages_test.go
@@ -16,7 +16,7 @@ func TestTextEmailInserts(t *testing.T) {
 	start := time.Now()
 
 	for i := 0; i < testRuns; i++ {
-		if _, err := Store(&testTextEmail); err != nil {
+		if _, err := Store(&testTextEmail, nil); err != nil {
 			t.Log("error ", err)
 			t.Fail()
 		}
@@ -54,7 +54,7 @@ func TestMimeEmailInserts(t *testing.T) {
 		start := time.Now()
 
 		for i := 0; i < testRuns; i++ {
-			if _, err := Store(&testMimeEmail); err != nil {
+			if _, err := Store(&testMimeEmail, nil); err != nil {
 				t.Log("error ", err)
 				t.Fail()
 			}
@@ -94,7 +94,7 @@ func TestRetrieveMimeEmail(t *testing.T) {
 				t.Logf("Testing mime email retrieval (tenant %s)", tenantID)
 			}
 
-			id, err := Store(&testMimeEmail)
+			id, err := Store(&testMimeEmail, nil)
 			if err != nil {
 				t.Log("error ", err)
 				t.Fail()
@@ -151,7 +151,7 @@ func TestMessageSummary(t *testing.T) {
 			t.Logf("Testing message summary (tenant %s)", tenantID)
 		}
 
-		if _, err := Store(&testMimeEmail); err != nil {
+		if _, err := Store(&testMimeEmail, nil); err != nil {
 			t.Log("error ", err)
 			t.Fail()
 		}
@@ -185,7 +185,7 @@ func BenchmarkImportText(b *testing.B) {
 	defer Close()
 
 	for i := 0; i < b.N; i++ {
-		if _, err := Store(&testTextEmail); err != nil {
+		if _, err := Store(&testTextEmail, nil); err != nil {
 			b.Log("error ", err)
 			b.Fail()
 		}
@@ -197,7 +197,7 @@ func BenchmarkImportMime(b *testing.B) {
 	defer Close()
 
 	for i := 0; i < b.N; i++ {
-		if _, err := Store(&testMimeEmail); err != nil {
+		if _, err := Store(&testMimeEmail, nil); err != nil {
 			b.Log("error ", err)
 			b.Fail()
 		}

--- a/internal/storage/reindex.go
+++ b/internal/storage/reindex.go
@@ -73,23 +73,25 @@ func ReindexAll() {
 				continue
 			}
 
-			from := &mail.Address{}
+			meta, err := GetMetadata(id)
+			if err != nil {
+				meta = Metadata{}
+			}
+
 			fromJSON := addressToSlice(env, "From")
 			if len(fromJSON) > 0 {
-				from = fromJSON[0]
+				meta.From = fromJSON[0]
 			} else if env.GetHeader("From") != "" {
-				from = &mail.Address{Name: env.GetHeader("From")}
+				meta.From = &mail.Address{Name: env.GetHeader("From")}
+			} else {
+				meta.From = nil
 			}
+			meta.To = addressToSlice(env, "To")
+			meta.Cc = addressToSlice(env, "Cc")
+			meta.Bcc = addressToSlice(env, "Bcc")
+			meta.ReplyTo = addressToSlice(env, "Reply-To")
 
-			obj := DBMailSummary{
-				From:    from,
-				To:      addressToSlice(env, "To"),
-				Cc:      addressToSlice(env, "Cc"),
-				Bcc:     addressToSlice(env, "Bcc"),
-				ReplyTo: addressToSlice(env, "Reply-To"),
-			}
-
-			MetadataJSON, err := json.Marshal(obj)
+			MetadataJSON, err := json.Marshal(meta)
 			if err != nil {
 				logger.Log().Errorf("[message] %s", err.Error())
 				continue

--- a/internal/storage/schemas/1.27.0.sql
+++ b/internal/storage/schemas/1.27.0.sql
@@ -1,0 +1,2 @@
+-- Add Username column to mailbox for SMTP username tracking
+ALTER TABLE {{ tenant "mailbox" }} ADD COLUMN Username TEXT;

--- a/internal/storage/search_test.go
+++ b/internal/storage/search_test.go
@@ -48,7 +48,7 @@ func TestSearch(t *testing.T) {
 
 			bufBytes := buf.Bytes()
 
-			if _, err := Store(&bufBytes); err != nil {
+			if _, err := Store(&bufBytes, nil); err != nil {
 				t.Log("error ", err)
 				t.Fail()
 			}
@@ -117,11 +117,11 @@ func TestSearchDelete100(t *testing.T) {
 		}
 
 		for i := 0; i < 100; i++ {
-			if _, err := Store(&testTextEmail); err != nil {
+			if _, err := Store(&testTextEmail, nil); err != nil {
 				t.Log("error ", err)
 				t.Fail()
 			}
-			if _, err := Store(&testMimeEmail); err != nil {
+			if _, err := Store(&testMimeEmail, nil); err != nil {
 				t.Log("error ", err)
 				t.Fail()
 			}
@@ -158,7 +158,7 @@ func TestSearchDelete1100(t *testing.T) {
 
 	t.Log("Testing search delete of 1100 messages")
 	for i := 0; i < 1100; i++ {
-		if _, err := Store(&testTextEmail); err != nil {
+		if _, err := Store(&testTextEmail, nil); err != nil {
 			t.Log("error ", err)
 			t.Fail()
 		}

--- a/internal/storage/structs.go
+++ b/internal/storage/structs.go
@@ -34,8 +34,8 @@ type Message struct {
 	Date time.Time
 	// Message tags
 	Tags []string
-	// SMTP username (if provided)
-	Username *string `json:"Username"`
+	// Username (if provided)
+	Username string
 	// Message body text
 	Text string
 	// Message body HTML
@@ -88,8 +88,8 @@ type MessageSummary struct {
 	Subject string
 	// Received RFC3339Nano date & time ([extended RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) format with optional nano seconds)
 	Created time.Time
-	// SMTP username (if provided)
-	Username *string
+	// Username (if provided)
+	Username string
 	// Message tags
 	Tags []string
 	// Message size in bytes (total)
@@ -107,14 +107,14 @@ type MailboxStats struct {
 	Tags   []string
 }
 
-// DBMailSummary struct for storing mail summary
-type DBMailSummary struct {
-	From    *mail.Address
-	To      []*mail.Address
-	Cc      []*mail.Address
-	Bcc     []*mail.Address
-	ReplyTo []*mail.Address
-	Username *string
+// Metadata struct for storing message metadata
+type Metadata struct {
+	From     *mail.Address   `json:"From,omitempty"`
+	To       []*mail.Address `json:"To,omitempty"`
+	Cc       []*mail.Address `json:"Cc,omitempty"`
+	Bcc      []*mail.Address `json:"Bcc,omitempty"`
+	ReplyTo  []*mail.Address `json:"ReplyTo,omitempty"`
+	Username string          `json:"Username,omitempty"`
 }
 
 // ListUnsubscribe contains a summary of List-Unsubscribe & List-Unsubscribe-Post headers

--- a/internal/storage/structs.go
+++ b/internal/storage/structs.go
@@ -34,6 +34,8 @@ type Message struct {
 	Date time.Time
 	// Message tags
 	Tags []string
+	// SMTP username (if provided)
+	Username *string `json:"Username"`
 	// Message body text
 	Text string
 	// Message body HTML
@@ -86,6 +88,8 @@ type MessageSummary struct {
 	Subject string
 	// Received RFC3339Nano date & time ([extended RFC3339](https://tools.ietf.org/html/rfc3339#section-5.6) format with optional nano seconds)
 	Created time.Time
+	// SMTP username (if provided)
+	Username *string
 	// Message tags
 	Tags []string
 	// Message size in bytes (total)
@@ -110,6 +114,7 @@ type DBMailSummary struct {
 	Cc      []*mail.Address
 	Bcc     []*mail.Address
 	ReplyTo []*mail.Address
+	Username *string
 }
 
 // ListUnsubscribe contains a summary of List-Unsubscribe & List-Unsubscribe-Post headers

--- a/internal/storage/tags.go
+++ b/internal/storage/tags.go
@@ -323,7 +323,7 @@ func findTagsInRawMessage(message *[]byte) []string {
 }
 
 // Returns tags found in email plus addresses (eg: test+tagname@example.com)
-func (d DBMailSummary) tagsFromPlusAddresses() []string {
+func (d Metadata) tagsFromPlusAddresses() []string {
 	tags := []string{}
 	for _, c := range d.To {
 		matches := addressPlusRe.FindAllStringSubmatch(c.Address, 1)

--- a/internal/storage/tags_test.go
+++ b/internal/storage/tags_test.go
@@ -24,7 +24,7 @@ func TestTags(t *testing.T) {
 		ids := []string{}
 
 		for i := 0; i < 10; i++ {
-			id, err := Store(&testMimeEmail)
+			id, err := Store(&testMimeEmail, nil)
 			if err != nil {
 				t.Log("error ", err)
 				t.Fail()
@@ -57,7 +57,7 @@ func TestTags(t *testing.T) {
 		}
 
 		// test 20 tags
-		id, err := Store(&testMimeEmail)
+		id, err := Store(&testMimeEmail, nil)
 		if err != nil {
 			t.Log("error ", err)
 			t.Fail()
@@ -124,7 +124,7 @@ func TestTags(t *testing.T) {
 		}
 
 		// test 20 tags
-		id, err = Store(&testTagEmail)
+		id, err = Store(&testTagEmail, nil)
 		if err != nil {
 			t.Log("error ", err)
 			t.Fail()
@@ -140,4 +140,49 @@ func TestTags(t *testing.T) {
 		Close()
 	}
 
+}
+func TestUsernameAutoTagging(t *testing.T) {
+	setup("")
+	defer Close()
+
+	username := "testuser"
+
+	t.Run("Auto-tagging enabled", func(t *testing.T) {
+		config.TagsUsername = true
+		id, err := Store(&testTextEmail, &username)
+		if err != nil {
+			t.Fatalf("Store failed: %v", err)
+		}
+		msg, err := GetMessage(id)
+		if err != nil {
+			t.Fatalf("GetMessage failed: %v", err)
+		}
+		found := false
+		for _, tag := range msg.Tags {
+			if tag == username {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected username '%s' in tags, got %v", username, msg.Tags)
+		}
+	})
+
+	t.Run("Auto-tagging disabled", func(t *testing.T) {
+		config.TagsUsername = false
+		id, err := Store(&testTextEmail, &username)
+		if err != nil {
+			t.Fatalf("Store failed: %v", err)
+		}
+		msg, err := GetMessage(id)
+		if err != nil {
+			t.Fatalf("GetMessage failed: %v", err)
+		}
+		for _, tag := range msg.Tags {
+			if tag == username {
+				t.Errorf("Did not expect username '%s' in tags when disabled, got %v", username, msg.Tags)
+			}
+		}
+	})
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -552,7 +552,7 @@ func insertEmailData(t *testing.T) {
 
 		bufBytes := buf.Bytes()
 
-		id, err := storage.Store(&bufBytes)
+		id, err := storage.Store(&bufBytes, nil)
 		if err != nil {
 			t.Log("error ", err)
 			t.Fail()

--- a/server/ui-src/components/message/Message.vue
+++ b/server/ui-src/components/message/Message.vue
@@ -418,6 +418,12 @@ export default {
 								<small class="ms-2">({{ getFileSize(message.Size) }})</small>
 							</td>
 						</tr>
+						<tr v-if="message.Username" class="small">
+							<th class="small">Username</th>
+							<td class="small">
+								{{ message.Username }}
+							</td>
+						</tr>
 						<tr class="small">
 							<th>Tags</th>
 							<td>


### PR DESCRIPTION
This PR enhances Mailpit by storing the SMTP/HTTP-authenticated username with each message, making it available for tagging and display in the UI.
## Key changes

- **Database & Backend**
  - Added a `Username` column to the `mailbox` table (with migration).
  - Updated message storage to save the username (if present) with each message.
  - Updated `DBMailSummary`, `MessageSummary`, and `Message` structs to include a `Username` field.

- **Tagging**
  - Added support for auto-tagging messages with the username if the `--tags-username` / `MP_TAGS_USERNAME` flag is set.

- **UI**
  - Updated the web UI (`Message.vue`) to display the username in the message header if present.

- **Testing & Debugging**
  - Updated and fixed Go tests and helpers for the new logic, including username auto-tagging.

- **Schema**
  - Added migration for the `Username` column (`1.27.0.sql`).

## Motivation

- Enables tracking and filtering of messages by user.

## Notes

- The initial schema and migrations have been reviewed to ensure a fresh DB is always correct.
- All tests pass after these changes.
