### PR TITLE
Allow version checking to be disabled

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,6 +93,7 @@ func init() {
 
 	rootCmd.Flags().StringVarP(&config.Database, "database", "d", config.Database, "Database to store persistent data")
 	rootCmd.Flags().BoolVar(&config.DisableWAL, "disable-wal", config.DisableWAL, "Disable WAL for local database (allows NFS mounted DBs)")
+	rootCmd.Flags().BoolVar(&config.DisableVersionCheck, "disable-version-check", config.DisableVersionCheck, "Disable version update checking")
 	rootCmd.Flags().IntVar(&config.Compression, "compression", config.Compression, "Compression level to store raw messages (0-3)")
 	rootCmd.Flags().StringVar(&config.Label, "label", config.Label, "Optional label identify this Mailpit instance")
 	rootCmd.Flags().StringVar(&config.TenantID, "tenant-id", config.TenantID, "Database tenant ID to isolate data")
@@ -203,6 +204,8 @@ func initConfigFromEnv() {
 	}
 
 	config.DisableWAL = getEnabledFromEnv("MP_DISABLE_WAL")
+
+	config.DisableVersionCheck = getEnabledFromEnv("MP_DISABLE_VERSION_CHECK")
 
 	if len(os.Getenv("MP_COMPRESSION")) > 0 {
 		config.Compression, _ = strconv.Atoi(os.Getenv("MP_COMPRESSION"))

--- a/config/config.go
+++ b/config/config.go
@@ -213,6 +213,9 @@ var (
 	// DisableHTMLCheck DEPRECATED 2024/04/13 - kept here to display console warning only
 	DisableHTMLCheck = false
 
+	// DisableVersionCheck disables version checking
+	DisableVersionCheck bool
+
 	// DemoMode disables SMTP relay, link checking & HTTP send functionality
 	DemoMode = false
 )

--- a/server/ui-src/components/AboutMailpit.vue
+++ b/server/ui-src/components/AboutMailpit.vue
@@ -91,20 +91,22 @@ export default {
 					<div class="modal-body">
 						<div class="row g-3">
 							<div class="col-xl-6">
-								<div class="row g-3" v-if="mailbox.appInfo.LatestVersion == ''">
-									<div class="col">
-										<div class="alert alert-warning mb-3">
-											There might be a newer version available. The check failed.
+								<div v-if="mailbox.appInfo.LatestVersion != 'disabled'">
+									<div class="row g-3" v-if="mailbox.appInfo.LatestVersion == ''">
+										<div class="col">
+											<div class="alert alert-warning mb-3">
+												There might be a newer version available. The check failed.
+											</div>
 										</div>
 									</div>
-								</div>
-								<div class="row g-3"
-									v-else-if="mailbox.appInfo.Version != mailbox.appInfo.LatestVersion">
-									<div class="col">
-										<a class="btn btn-warning d-block mb-3"
-											:href="'https://github.com/axllent/mailpit/releases/tag/' + mailbox.appInfo.LatestVersion">
-											A new version of Mailpit ({{ mailbox.appInfo.LatestVersion }}) is available.
-										</a>
+									<div class="row g-3"
+										v-else-if="mailbox.appInfo.Version != mailbox.appInfo.LatestVersion">
+										<div class="col">
+											<a class="btn btn-warning d-block mb-3"
+												:href="'https://github.com/axllent/mailpit/releases/tag/' + mailbox.appInfo.LatestVersion">
+												A new version of Mailpit ({{ mailbox.appInfo.LatestVersion }}) is available.
+											</a>
+										</div>
 									</div>
 								</div>
 								<div class="row g-3">


### PR DESCRIPTION
This PR implements a new flag to allow version checking to be fully turned off.

##  Features Added

**New Configuration Options:**
- `--disable-version-check` / `MP_DISABLE_VERSION_CHECK`: Disables calling out to GitHub for the latest version.

This change is non-breaking.

Happy to leave this out for now, too, given your limited time docs added as part of  https://github.com/axllent/mailpit-website/pull/21


