### PR TITLE
Feature: Add SMTPDropRejectedRecipients flag to silently drop emails to rejected recipients

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -126,6 +126,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&config.SMTPStrictRFCHeaders, "smtp-strict-rfc-headers", config.SMTPStrictRFCHeaders, "Return SMTP error if message headers contain <CR><CR><LF>")
 	rootCmd.Flags().IntVar(&config.SMTPMaxRecipients, "smtp-max-recipients", config.SMTPMaxRecipients, "Maximum SMTP recipients allowed")
 	rootCmd.Flags().StringVar(&config.SMTPAllowedRecipients, "smtp-allowed-recipients", config.SMTPAllowedRecipients, "Only allow SMTP recipients matching a regular expression (default allow all)")
+	rootCmd.Flags().BoolVar(&config.SMTPSilentlyDropRejectedRecipients, "smtp-silently-drop-rejected-recipients", config.SMTPSilentlyDropRejectedRecipients, "Accept emails to rejected recipients with 2xx response but silently drop them")
 	rootCmd.Flags().BoolVar(&smtpd.DisableReverseDNS, "smtp-disable-rdns", smtpd.DisableReverseDNS, "Disable SMTP reverse DNS lookups")
 
 	// SMTP relay
@@ -300,6 +301,9 @@ func initConfigFromEnv() {
 	}
 	if len(os.Getenv("MP_SMTP_ALLOWED_RECIPIENTS")) > 0 {
 		config.SMTPAllowedRecipients = os.Getenv("MP_SMTP_ALLOWED_RECIPIENTS")
+	}
+	if getEnabledFromEnv("MP_SMTP_SILENTLY_DROP_REJECTED_RECIPIENTS") {
+		config.SMTPSilentlyDropRejectedRecipients = true
 	}
 	if getEnabledFromEnv("MP_SMTP_DISABLE_RDNS") {
 		smtpd.DisableReverseDNS = true

--- a/config/config.go
+++ b/config/config.go
@@ -181,6 +181,9 @@ var (
 	// SMTPAllowedRecipientsRegexp is the compiled version of SMTPAllowedRecipients
 	SMTPAllowedRecipientsRegexp *regexp.Regexp
 
+	// SMTPSilentlyDropRejectedRecipients if true, will accept emails to rejected recipients with 2xx response but silently drop them
+	SMTPSilentlyDropRejectedRecipients bool
+
 	// POP3Listen address - if set then Mailpit will start the POP3 server and listen on this address
 	POP3Listen = "[::]:1110"
 

--- a/internal/smtpd/main.go
+++ b/internal/smtpd/main.go
@@ -194,15 +194,16 @@ func listenAndServe(addr string, handler MsgIDHandler, authHandler AuthHandler) 
 
 	Debug = true // to enable Mailpit logging
 	srv := &Server{
-		Addr:              addr,
-		MsgIDHandler:      handler,
-		HandlerRcpt:       handlerRcpt,
-		AppName:           "Mailpit",
-		Hostname:          "",
-		AuthHandler:       nil,
-		AuthRequired:      false,
-		MaxRecipients:     config.SMTPMaxRecipients,
-		DisableReverseDNS: DisableReverseDNS,
+		Addr:                           addr,
+		MsgIDHandler:                   handler,
+		HandlerRcpt:                    handlerRcpt,
+		AppName:                        "Mailpit",
+		Hostname:                       "",
+		AuthHandler:                    nil,
+		AuthRequired:                   false,
+		MaxRecipients:                  config.SMTPMaxRecipients,
+		SilentlyDropRejectedRecipients: config.SMTPSilentlyDropRejectedRecipients,
+		DisableReverseDNS:              DisableReverseDNS,
 		LogRead: func(remoteIP, verb, line string) {
 			logger.Log().Debugf("[smtpd] %s (%s) %s", verbLogTranslator(verb), remoteIP, line)
 		},

--- a/internal/smtpd/smtpd.go
+++ b/internal/smtpd/smtpd.go
@@ -92,26 +92,27 @@ type LogFunc func(remoteIP, verb, line string)
 
 // Server is an SMTP server.
 type Server struct {
-	Addr              string // TCP address to listen on, defaults to ":25" (all addresses, port 25) if empty
-	AppName           string
-	AuthHandler       AuthHandler
-	AuthMechs         map[string]bool // Override list of allowed authentication mechanisms. Currently supported: LOGIN, PLAIN, CRAM-MD5. Enabling LOGIN and PLAIN will reduce RFC 4954 compliance.
-	AuthRequired      bool            // Require authentication for every command except AUTH, EHLO, HELO, NOOP, RSET or QUIT as per RFC 4954. Ignored if AuthHandler is not configured.
-	DisableReverseDNS bool            // Disable reverse DNS lookups, enforces "unknown" hostname
-	Handler           Handler
-	HandlerRcpt       HandlerRcpt
-	Hostname          string
-	LogRead           LogFunc
-	LogWrite          LogFunc
-	MaxSize           int // Maximum message size allowed, in bytes
-	MaxRecipients     int // Maximum number of recipients, defaults to 100.
-	MsgIDHandler      MsgIDHandler
-	Timeout           time.Duration
-	TLSConfig         *tls.Config
-	TLSListener       bool        // Listen for incoming TLS connections only (not recommended as it may reduce compatibility). Ignored if TLS is not configured.
-	TLSRequired       bool        // Require TLS for every command except NOOP, EHLO, STARTTLS, or QUIT as per RFC 3207. Ignored if TLS is not configured.
-	Protocol          string      // Default tcp, supports unix
-	SocketPerm        fs.FileMode // if using Unix socket, socket permissions
+	Addr                           string // TCP address to listen on, defaults to ":25" (all addresses, port 25) if empty
+	AppName                        string
+	AuthHandler                    AuthHandler
+	AuthMechs                      map[string]bool // Override list of allowed authentication mechanisms. Currently supported: LOGIN, PLAIN, CRAM-MD5. Enabling LOGIN and PLAIN will reduce RFC 4954 compliance.
+	AuthRequired                   bool            // Require authentication for every command except AUTH, EHLO, HELO, NOOP, RSET or QUIT as per RFC 4954. Ignored if AuthHandler is not configured.
+	DisableReverseDNS              bool            // Disable reverse DNS lookups, enforces "unknown" hostname
+	Handler                        Handler
+	HandlerRcpt                    HandlerRcpt
+	Hostname                       string
+	LogRead                        LogFunc
+	LogWrite                       LogFunc
+	MaxSize                        int // Maximum message size allowed, in bytes
+	MaxRecipients                  int // Maximum number of recipients, defaults to 100.
+	MsgIDHandler                   MsgIDHandler
+	SilentlyDropRejectedRecipients bool // Accept emails to rejected recipients with 2xx response but silently drop them
+	Timeout                        time.Duration
+	TLSConfig                      *tls.Config
+	TLSListener                    bool        // Listen for incoming TLS connections only (not recommended as it may reduce compatibility). Ignored if TLS is not configured.
+	TLSRequired                    bool        // Require TLS for every command except NOOP, EHLO, STARTTLS, or QUIT as per RFC 3207. Ignored if TLS is not configured.
+	Protocol                       string      // Default tcp, supports unix
+	SocketPerm                     fs.FileMode // if using Unix socket, socket permissions
 
 	inShutdown   int32 // server was closed or shutdown
 	openSessions int32 // count of open sessions
@@ -363,6 +364,7 @@ func (s *session) serve() {
 	var from string
 	var gotFrom bool
 	var to []string
+	var hasRejectedRecipients bool
 	var buffer bytes.Buffer
 
 	// RFC 5321 specifies support for minimum of 100 recipients is required.
@@ -397,6 +399,7 @@ loop:
 			from = ""
 			gotFrom = false
 			to = nil
+			hasRejectedRecipients = false
 			buffer.Reset()
 		case "EHLO":
 			s.remoteName = args
@@ -406,6 +409,7 @@ loop:
 			from = ""
 			gotFrom = false
 			to = nil
+			hasRejectedRecipients = false
 			buffer.Reset()
 		case "MAIL":
 			if s.srv.TLSConfig != nil && s.srv.TLSRequired && !s.tls {
@@ -457,6 +461,7 @@ loop:
 			}
 
 			to = nil
+			hasRejectedRecipients = false
 			buffer.Reset()
 		case "RCPT":
 			if s.srv.TLSConfig != nil && s.srv.TLSRequired && !s.tls {
@@ -492,6 +497,9 @@ loop:
 					if accept {
 						to = append(to, match[1])
 						s.writef("250 2.1.5 Ok")
+					} else if s.srv.SilentlyDropRejectedRecipients {
+						hasRejectedRecipients = true
+						s.writef("250 2.1.5 Ok")
 					} else {
 						s.writef("550 5.1.0 Requested action not taken: mailbox unavailable")
 					}
@@ -506,7 +514,8 @@ loop:
 				s.writef("530 5.7.0 Authentication required")
 				break
 			}
-			if !gotFrom || len(to) == 0 {
+			hasRecipients := len(to) > 0 || hasRejectedRecipients
+			if !gotFrom || !hasRecipients {
 				s.writef("503 5.5.1 Bad sequence of commands (MAIL & RCPT required before DATA)")
 				break
 			}
@@ -536,11 +545,13 @@ loop:
 
 			// Create Received header & write message body into buffer.
 			buffer.Reset()
-			buffer.Write(s.makeHeaders(to))
+			if len(to) > 0 {
+				buffer.Write(s.makeHeaders(to))
+			}
 			buffer.Write(data)
 
-			// Pass mail on to handler.
-			if s.srv.Handler != nil {
+			// Pass mail on to handler only if there are valid recipients.
+			if len(to) > 0 && s.srv.Handler != nil {
 				err := s.srv.Handler(s.conn.RemoteAddr(), from, to, buffer.Bytes())
 				if err != nil {
 					checkErrFormat := regexp.MustCompile(`^([2-5][0-9]{2})[\s\-](.+)$`)
@@ -552,7 +563,7 @@ loop:
 					break
 				}
 				s.writef("250 2.0.0 Ok: queued")
-			} else if s.srv.MsgIDHandler != nil {
+			} else if len(to) > 0 && s.srv.MsgIDHandler != nil {
 				msgID, err := s.srv.MsgIDHandler(s.conn.RemoteAddr(), from, to, buffer.Bytes(), s.username)
 				if err != nil {
 					checkErrFormat := regexp.MustCompile(`^([2-5][0-9]{2})[\s\-](.+)$`)
@@ -570,6 +581,13 @@ loop:
 					s.writef("250 2.0.0 Ok: queued")
 				}
 			} else {
+				if hasRejectedRecipients && Debug {
+					if s.srv.LogWrite != nil {
+						s.srv.LogWrite(s.remoteIP, "DEBUG", "Message from sender silently dropped (rejected recipients)")
+					} else {
+						log.Printf("%s DEBUG Message from sender silently dropped (rejected recipients)", s.remoteIP)
+					}
+				}
 				s.writef("250 2.0.0 Ok: queued")
 			}
 
@@ -577,6 +595,7 @@ loop:
 			from = ""
 			gotFrom = false
 			to = nil
+			hasRejectedRecipients = false
 			buffer.Reset()
 		case "QUIT":
 			s.writef("221 2.0.0 %s %s ESMTP Service closing transmission channel", s.srv.Hostname, s.srv.AppName)
@@ -590,6 +609,7 @@ loop:
 			from = ""
 			gotFrom = false
 			to = nil
+			hasRejectedRecipients = false
 			buffer.Reset()
 		case "NOOP":
 			s.writef("250 2.0.0 Ok")
@@ -666,6 +686,7 @@ loop:
 			from = ""
 			gotFrom = false
 			to = nil
+			hasRejectedRecipients = false
 			buffer.Reset()
 		case "AUTH":
 			if s.srv.TLSConfig != nil && s.srv.TLSRequired && !s.tls {


### PR DESCRIPTION
Hi @axllent, 

here is the pull request as discussed in https://github.com/axllent/mailpit/issues/492 :-) Please let me know if this works.

## Problem Statement

When using Mailpit in test environments with `--smtp-allowed-recipients` restrictions, some standard software and custom applications don't handle `550 5.1.0 Requested action not taken: mailbox unavailable` responses well. These applications expect a forwarding relay that accepts all recipients with `2xx` responses and handles forwarding/rejection asynchronously (e.g. Amazon SES, Sendgrid, Mailgun etc).

## Solution

This PR introduces a new flag `--smtp-silently-drop-rejected-recipients` that modifies SMTP behavior:

- **When disabled (default)**: Maintains existing behavior - rejected recipients get `550` error responses
- **When enabled**: Rejected recipients receive `250 OK` responses but messages are silently dropped instead of being processed by handlers

## Behavior Examples

### Before (Default Behavior)
```
C: RCPT TO:<valid@example.com>
S: 250 2.1.5 Ok
C: RCPT TO:<invalid@blocked.com>  
S: 550 5.1.0 Requested action not taken: mailbox unavailable
```

### After (With Flag Enabled)
```
C: RCPT TO:<valid@example.com>
S: 250 2.1.5 Ok
C: RCPT TO:<invalid@blocked.com>
S: 250 2.1.5 Ok
C: DATA
S: 354 Start mail input; end with <CR><LF>.<CR><LF>
C: [message data]
C: .
S: 250 2.0.0 Ok: queued
```

The message is processed normally for valid recipients, but silently dropped for invalid ones.
