### PR TITLE
Set HELO/EHLO hostname when connecting to external server #146

### DIFF
--- a/internal/smtpd/forward.go
+++ b/internal/smtpd/forward.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/smtp"
+	"os"
 	"strings"
 
 	"github.com/axllent/mailpit/config"
@@ -57,6 +58,13 @@ func createForwardingSMTPClient(config config.SMTPForwardConfigStruct, addr stri
 		if err = client.StartTLS(tlsConf); err != nil {
 			_ = client.Close()
 			return nil, fmt.Errorf("error creating StartTLS config: %v", err)
+		}
+	}
+
+	// Set the hostname for HELO/EHLO
+	if hostname, err := os.Hostname(); err == nil {
+		if err := client.Hello(hostname); err != nil {
+			return nil, fmt.Errorf("error saying HELO/EHLO to %s: %v", addr, err)
 		}
 	}
 

--- a/internal/smtpd/relay.go
+++ b/internal/smtpd/relay.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/smtp"
+	"os"
 	"strings"
 
 	"github.com/axllent/mailpit/config"
@@ -91,6 +92,13 @@ func createRelaySMTPClient(config config.SMTPRelayConfigStruct, addr string) (*s
 		if err = client.StartTLS(tlsConf); err != nil {
 			_ = client.Close()
 			return nil, fmt.Errorf("error creating StartTLS config: %v", err)
+		}
+	}
+
+	// Set the hostname for HELO/EHLO
+	if hostname, err := os.Hostname(); err == nil {
+		if err := client.Hello(hostname); err != nil {
+			return nil, fmt.Errorf("error saying HELO/EHLO to %s: %v", addr, err)
 		}
 	}
 


### PR DESCRIPTION
When a message is forwarded or released, Mailpit introduces itself as `localhost` to the upstream server. This happens because `net/smtp` forces the value to be `localhost` if `client.Hello` is not called. This is explicitly documented at https://pkg.go.dev/net/smtp#Client.Hello

Therefore, both `internal/smtpd/relay.go` (`createRelaySMTPClient`) and `internal/smtpd/forward.go` (`createForwardingSMTPClient`) should either call `client.Hello(os.Hostname())` or create a config (perhaps `config.HeloHostname`) and use `client.Hello()` with that value immediately before returning from either of those functions. (The HELO/EHLO command comes after TLS negotiation but before any other SMTP commands.) This commit does the former.

Without this feature, Mailpit cannot be used in combination with Google Workspace's SMTP Relay functionality, as it rejects any connection that identifies itself as `localhost`.