### PR TITLE
Add --no-release-check to version subcommand

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -16,6 +16,7 @@ var versionCmd = &cobra.Command{
 	Long:  `Display the current version & update information (if available).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		update, _ := cmd.Flags().GetBool("update")
+		noReleaseCheck, _ := cmd.Flags().GetBool("no-release-check")
 
 		if update {
 			// Update the application
@@ -32,23 +33,25 @@ var versionCmd = &cobra.Command{
 		fmt.Printf("%s %s compiled with %s on %s/%s\n",
 			os.Args[0], config.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 
-		release, err := config.GHRUConfig.Latest()
-		if err != nil {
-			fmt.Printf("Error checking for latest release: %s\n", err)
-			os.Exit(1)
-		}
+		if !noReleaseCheck {
+			release, err := config.GHRUConfig.Latest()
+			if err != nil {
+				fmt.Printf("Error checking for latest release: %s\n", err)
+				os.Exit(1)
+			}
 
-		// The latest version is the same version
-		if release.Tag == config.Version {
-			os.Exit(0)
-		}
+			// The latest version is the same version
+			if release.Tag == config.Version {
+				os.Exit(0)
+			}
 
-		// A newer release is available
-		fmt.Printf(
-			"\nUpdate available: %s\nRun `%s version -u` to update (requires read/write access to install directory).\n",
-			release.Tag,
-			os.Args[0],
-		)
+			// A newer release is available
+			fmt.Printf(
+				"\nUpdate available: %s\nRun `%s version -u` to update (requires read/write access to install directory).\n",
+				release.Tag,
+				os.Args[0],
+			)
+		}
 	},
 }
 
@@ -57,4 +60,6 @@ func init() {
 
 	versionCmd.Flags().
 		BoolP("update", "u", false, "update to latest version")
+	versionCmd.Flags().
+		Bool("no-release-check", false, "do not check online for the latest release version")
 }


### PR DESCRIPTION
Hi! I maintain the Mailpit package in Nixpkgs.

We run `mailpit version` as a quick check in CI to ensure the binary works. This runs in a sandbox without network access. With the new version check, this indicates failure with exit status 1. Hope this change to add a flag is okay. 🙂