### PR TITLE
Feat(Docker): Add non-root user to manifest to prevent potential escalation and exploitation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,8 @@ EXPOSE 1025/tcp 1110/tcp 8025/tcp
 
 HEALTHCHECK --interval=15s --start-period=10s --start-interval=1s CMD ["/mailpit", "readyz"]
 
+RUN adduser --disabled-password --gecos "" -u 1001 non-root
+
+USER non-root
+
 ENTRYPOINT ["/mailpit"]


### PR DESCRIPTION
If we don’t specify a particular user in the Dockerfile, processes in the container will run as the superuser (root). This is indeed a security issue. Root access in the container allows software installation with the package manager and further exploitation with container breakout (container root === host root). I resolved this issue by switching to a non-root user without any passwords before actually starting the binary.

Before:
<img width="1210" height="410" alt="image" src="https://github.com/user-attachments/assets/bc98c810-bcbe-4186-9aac-a9087a101e35" />

After:
<img width="1153" height="418" alt="image" src="https://github.com/user-attachments/assets/2e73f09a-70e5-4243-8a99-ed3fb0b8d1fd" />


