### PR TITLE
feat: add default release address configuration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -331,6 +331,7 @@ func initConfigFromEnv() {
 	config.SMTPRelayConfig.OverrideFrom = os.Getenv("MP_SMTP_RELAY_OVERRIDE_FROM")
 	config.SMTPRelayConfig.AllowedRecipients = os.Getenv("MP_SMTP_RELAY_ALLOWED_RECIPIENTS")
 	config.SMTPRelayConfig.BlockedRecipients = os.Getenv("MP_SMTP_RELAY_BLOCKED_RECIPIENTS")
+	config.SMTPRelayConfig.DefaultReleaseTo = os.Getenv("MP_SMTP_RELAY_DEFAULT_RELEASE_TO")
 	config.SMTPRelayConfig.PreserveMessageIDs = getEnabledFromEnv("MP_SMTP_RELAY_PRESERVE_MESSAGE_IDS")
 	config.SMTPRelayConfig.ForwardSMTPErrors = getEnabledFromEnv("MP_SMTP_RELAY_FWD_SMTP_ERRORS")
 

--- a/config/config.go
+++ b/config/config.go
@@ -251,6 +251,7 @@ type SMTPRelayConfigStruct struct {
 	AllowedRecipientsRegexp *regexp.Regexp // compiled regexp using AllowedRecipients
 	BlockedRecipients       string         `yaml:"blocked-recipients"` // regex, if set prevents relating to these addresses
 	BlockedRecipientsRegexp *regexp.Regexp // compiled regexp using BlockedRecipients
+	DefaultReleaseTo        string         `yaml:"default-release-to"` // default "To" address for releasing messages
 	PreserveMessageIDs      bool           `yaml:"preserve-message-ids"` // preserve the original Message-ID when relaying
 	ForwardSMTPErrors       bool           `yaml:"forward-smtp-errors"`  // whether to log smtp-errors or forward them to upstream-client
 

--- a/server/apiv1/application.go
+++ b/server/apiv1/application.go
@@ -60,6 +60,7 @@ func WebUIConfig(w http.ResponseWriter, _ *http.Request) {
 		conf.Body.MessageRelay.ReturnPath = config.SMTPRelayConfig.ReturnPath
 		conf.Body.MessageRelay.AllowedRecipients = config.SMTPRelayConfig.AllowedRecipients
 		conf.Body.MessageRelay.BlockedRecipients = config.SMTPRelayConfig.BlockedRecipients
+		conf.Body.MessageRelay.DefaultReleaseTo = config.SMTPRelayConfig.DefaultReleaseTo
 		conf.Body.MessageRelay.OverrideFrom = config.SMTPRelayConfig.OverrideFrom
 		conf.Body.MessageRelay.PreserveMessageIDs = config.SMTPRelayConfig.PreserveMessageIDs
 

--- a/server/apiv1/swaggerResponses.go
+++ b/server/apiv1/swaggerResponses.go
@@ -74,6 +74,8 @@ type webUIConfigurationResponse struct {
 			AllowedRecipients string
 			// Block relaying to these recipients (regex)
 			BlockedRecipients string
+			// Default "To" address for releasing messages (pre-populates the release form)
+			DefaultReleaseTo string
 			// Overrides the "From" address for all relayed messages
 			OverrideFrom string
 			// Preserve the original Message-IDs when relaying messages

--- a/server/ui-src/components/message/MessageRelease.vue
+++ b/server/ui-src/components/message/MessageRelease.vue
@@ -44,7 +44,12 @@ export default {
 		// include only unique email addresses, regardless of casing
 		this.allAddresses = JSON.parse(JSON.stringify([...new Map(a.map((ad) => [ad.toLowerCase(), ad])).values()]));
 
-		this.addresses = this.allAddresses;
+		// use configured default release address if set, otherwise use all message addresses
+		if (this.mailbox.uiConfig.MessageRelay.DefaultReleaseTo) {
+			this.addresses = [this.mailbox.uiConfig.MessageRelay.DefaultReleaseTo];
+		} else {
+			this.addresses = this.allAddresses;
+		}
 	},
 
 	methods: {
@@ -160,6 +165,10 @@ export default {
 
 					<h6>Notes</h6>
 					<ul>
+						<li v-if="mailbox.uiConfig.MessageRelay.DefaultReleaseTo != ''" class="form-text">
+							A <b>default release address</b> has been configured:
+							<code>{{ mailbox.uiConfig.MessageRelay.DefaultReleaseTo }}</code>
+						</li>
 						<li v-if="mailbox.uiConfig.MessageRelay.AllowedRecipients != ''" class="form-text">
 							A recipient <b>allowlist</b> has been configured. Any mail address not matching the
 							following will be rejected:


### PR DESCRIPTION
## Summary

This PR adds a new configuration option to pre-populate the release form with a default recipient address, addressing issue #594.

## Changes

- **config/config.go**: Add `DefaultReleaseTo` field to `SMTPRelayConfigStruct` with YAML tag `default-release-to`
- **cmd/root.go**: Load `MP_SMTP_RELAY_DEFAULT_RELEASE_TO` environment variable
- **server/apiv1/application.go**: Expose `DefaultReleaseTo` in WebUI configuration API
- **server/apiv1/swaggerResponses.go**: Add API documentation for new field
- **server/ui-src/components/message/MessageRelease.vue**: 
  - Use default address when configured instead of original message recipients
  - Display note in the release modal when default address is configured

## Usage

### Environment Variable
```bash
MP_SMTP_RELAY_DEFAULT_RELEASE_TO=myemail@example.com
```

### YAML Configuration
```yaml
default-release-to: myemail@example.com
```

## Behavior

- When `DefaultReleaseTo` is configured, the release form pre-populates with this address instead of the original message recipients (To/Cc/Bcc)
- The original message addresses remain available in the dropdown for flexibility
- When not configured, the existing behavior is preserved (all original recipients are pre-selected)
- A note is displayed in the release modal when a default address is configured

## Testing

- Verified that when `DefaultReleaseTo` is set, it pre-populates the release form
- Verified that original message addresses remain available as options
- Verified that existing behavior is preserved when the option is not set

Closes #594