### PR TITLE
fix macOS group detection in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ done
 OS=
 case "$(uname -s)" in
 Linux) OS="linux" ;;
-Darwin) OS="Darwin" ;;
+Darwin) OS="darwin" ;;
 *)
     echo "OS not supported."
     exit 2


### PR DESCRIPTION
This fixes https://github.com/axllent/mailpit/issues/618.

On macOS:
◦  Ran the installer via sudo sh install.sh:
▪  Previously: failed with chown: root: illegal group name.
▪  Now: completes successfully, binary installed to /usr/local/bin/mailpit.

From the repo:
◦  go test ./... (all tests pass, some packages have no test files which is expected).