### PR TITLE
Add Attachments and Links tabs to message view

### DIFF
--- a/internal/linkcheck/main.go
+++ b/internal/linkcheck/main.go
@@ -94,6 +94,13 @@ func extractHTMLLinks(msg *storage.Message) []string {
 	return links
 }
 
+// ExtractLinks extracts all unique links from a message (without checking HTTP status)
+func ExtractLinks(msg *storage.Message) []string {
+	allLinks := extractHTMLLinks(msg)
+	allLinks = strUnique(append(allLinks, extractTextLinks(msg)...))
+	return allLinks
+}
+
 // strUnique return a slice of unique strings from a slice
 func strUnique(strSlice []string) []string {
 	keys := make(map[string]bool)

--- a/internal/linkcheck/structs.go
+++ b/internal/linkcheck/structs.go
@@ -19,3 +19,13 @@ type Link struct {
 	// HTTP status definition
 	Status string `json:"Status"`
 }
+
+// LinksResponse represents the extracted links response
+//
+// swagger:model LinksResponse
+type LinksResponse struct {
+	// Total number of links
+	Total int `json:"Total"`
+	// Extracted links
+	Links []string `json:"Links"`
+}

--- a/server/apiv1/other.go
+++ b/server/apiv1/other.go
@@ -2,6 +2,10 @@ package apiv1
 
 import (
 	"bytes"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -186,5 +190,190 @@ func SpamAssassinCheck(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(summary); err != nil {
 		httpError(w, err.Error())
+	}
+}
+
+// GetLinks returns all links extracted from the email
+func GetLinks(w http.ResponseWriter, r *http.Request) {
+	// swagger:route GET /api/v1/message/{ID}/links other GetLinksParams
+	//
+	// # Get message links
+	//
+	// Returns all unique links extracted from the message HTML and text.
+	//
+	// The ID can be set to `latest` to return the latest message.
+	//
+	//	Produces:
+	//	  - application/json
+	//
+	//	Schemes: http, https
+	//
+	//	Responses:
+	//	  200: LinksResponse
+	//    400: ErrorResponse
+	//    404: NotFoundResponse
+
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	if id == "latest" {
+		var err error
+		id, err = storage.LatestID(r)
+		if err != nil {
+			fourOFour(w)
+			return
+		}
+	}
+
+	msg, err := storage.GetMessage(id)
+	if err != nil {
+		fourOFour(w)
+		return
+	}
+
+	links := linkcheck.ExtractLinks(msg)
+
+	response := linkcheck.LinksResponse{
+		Total: len(links),
+		Links: links,
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		httpError(w, err.Error())
+	}
+}
+
+// AttachmentDetail represents detailed attachment information including hashes
+type AttachmentDetail struct {
+	// Part ID
+	PartID string `json:"PartID"`
+	// File name
+	FileName string `json:"FileName"`
+	// Content type
+	ContentType string `json:"ContentType"`
+	// Content ID
+	ContentID string `json:"ContentID"`
+	// File size in bytes
+	Size uint64 `json:"Size"`
+	// MD5 hash
+	MD5 string `json:"MD5"`
+	// SHA1 hash
+	SHA1 string `json:"SHA1"`
+	// SHA256 hash
+	SHA256 string `json:"SHA256"`
+}
+
+// AttachmentDetailsResponse contains all attachment details
+type AttachmentDetailsResponse struct {
+	// Attachments
+	Attachments []AttachmentDetail `json:"Attachments"`
+	// Inline attachments
+	Inline []AttachmentDetail `json:"Inline"`
+}
+
+// GetAttachmentDetails returns detailed information about all attachments including hashes
+func GetAttachmentDetails(w http.ResponseWriter, r *http.Request) {
+	// swagger:route GET /api/v1/message/{ID}/attachments other GetAttachmentDetailsParams
+	//
+	// # Get attachment details
+	//
+	// Returns detailed information about all attachments including file hashes.
+	//
+	// The ID can be set to `latest` to return the latest message.
+	//
+	//	Produces:
+	//	  - application/json
+	//
+	//	Schemes: http, https
+	//
+	//	Responses:
+	//	  200: AttachmentDetailsResponse
+	//    400: ErrorResponse
+	//    404: NotFoundResponse
+
+	vars := mux.Vars(r)
+	id := vars["id"]
+
+	if id == "latest" {
+		var err error
+		id, err = storage.LatestID(r)
+		if err != nil {
+			fourOFour(w)
+			return
+		}
+	}
+
+	raw, err := storage.GetMessageRaw(id)
+	if err != nil {
+		fourOFour(w)
+		return
+	}
+
+	e := bytes.NewReader(raw)
+
+	parser := enmime.NewParser(enmime.DisableCharacterDetection(true))
+
+	env, err := parser.ReadEnvelope(e)
+	if err != nil {
+		httpError(w, err.Error())
+		return
+	}
+
+	response := AttachmentDetailsResponse{
+		Attachments: []AttachmentDetail{},
+		Inline:      []AttachmentDetail{},
+	}
+
+	// Process regular attachments
+	for _, a := range env.Attachments {
+		if a.FileName != "" || a.ContentID != "" {
+			detail := createAttachmentDetail(a)
+			response.Attachments = append(response.Attachments, detail)
+		}
+	}
+
+	// Process inline attachments
+	for _, a := range env.Inlines {
+		if a.FileName != "" || a.ContentID != "" {
+			detail := createAttachmentDetail(a)
+			response.Inline = append(response.Inline, detail)
+		}
+	}
+
+	// Process other parts
+	for _, a := range env.OtherParts {
+		if a.FileName != "" || a.ContentID != "" {
+			detail := createAttachmentDetail(a)
+			response.Inline = append(response.Inline, detail)
+		}
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		httpError(w, err.Error())
+	}
+}
+
+// createAttachmentDetail creates an AttachmentDetail from an enmime.Part
+func createAttachmentDetail(a *enmime.Part) AttachmentDetail {
+	md5Hash := md5.Sum(a.Content)
+	sha1Hash := sha1.Sum(a.Content)
+	sha256Hash := sha256.Sum256(a.Content)
+
+	fileName := a.FileName
+	if fileName == "" {
+		fileName = a.ContentID
+	}
+
+	return AttachmentDetail{
+		PartID:      a.PartID,
+		FileName:    fileName,
+		ContentType: a.ContentType,
+		ContentID:   a.ContentID,
+		Size:        uint64(len(a.Content)),
+		MD5:         hex.EncodeToString(md5Hash[:]),
+		SHA1:        hex.EncodeToString(sha1Hash[:]),
+		SHA256:      hex.EncodeToString(sha256Hash[:]),
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -175,6 +175,8 @@ func apiRoutes() *mux.Router {
 	r.HandleFunc(config.Webroot+"api/v1/message/{id}/raw", middleWareFunc(apiv1.DownloadRaw)).Methods("GET")
 	r.HandleFunc(config.Webroot+"api/v1/message/{id}/release", middleWareFunc(apiv1.ReleaseMessage)).Methods("POST")
 	r.HandleFunc(config.Webroot+"api/v1/message/{id}/html-check", middleWareFunc(apiv1.HTMLCheck)).Methods("GET")
+	r.HandleFunc(config.Webroot+"api/v1/message/{id}/links", middleWareFunc(apiv1.GetLinks)).Methods("GET")
+	r.HandleFunc(config.Webroot+"api/v1/message/{id}/attachments", middleWareFunc(apiv1.GetAttachmentDetails)).Methods("GET")
 	r.HandleFunc(config.Webroot+"api/v1/message/{id}/link-check", middleWareFunc(apiv1.LinkCheck)).Methods("GET")
 	if config.EnableSpamAssassin != "" {
 		r.HandleFunc(config.Webroot+"api/v1/message/{id}/sa-check", middleWareFunc(apiv1.SpamAssassinCheck)).Methods("GET")

--- a/server/ui-src/components/message/AttachmentDetails.vue
+++ b/server/ui-src/components/message/AttachmentDetails.vue
@@ -1,0 +1,253 @@
+<script>
+import axios from "axios";
+import commonMixins from "../../mixins/CommonMixins";
+
+export default {
+	mixins: [commonMixins],
+
+	props: {
+		message: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			error: false,
+			attachments: false,
+			loaded: false,
+			loading: false,
+		};
+	},
+
+	computed: {
+		totalAttachments() {
+			if (!this.attachments) return 0;
+			return this.attachments.Attachments.length + this.attachments.Inline.length;
+		},
+	},
+
+	mounted() {
+		this.loadAttachments();
+	},
+
+	methods: {
+		loadAttachments() {
+			this.loading = true;
+			const uri = this.resolve("/api/v1/message/" + this.message.ID + "/attachments");
+
+			axios
+				.get(uri, null)
+				.then((result) => {
+					this.attachments = result.data;
+					this.error = false;
+					this.loaded = true;
+				})
+				.catch((error) => {
+					if (error.response && error.response.data) {
+						if (error.response.data.Error) {
+							this.error = error.response.data.Error;
+						} else {
+							this.error = error.response.data;
+						}
+					} else if (error.request) {
+						this.error = "Error sending data to the server. Please try again.";
+					} else {
+						this.error = error.message;
+					}
+				})
+				.then(() => {
+					this.loading = false;
+				});
+		},
+
+		copyToClipboard(text) {
+			navigator.clipboard.writeText(text);
+		},
+	},
+};
+</script>
+
+<template>
+	<div class="pe-3">
+		<div class="row mb-3 align-items-center">
+			<div class="col">
+				<h4 class="mb-0">
+					<template v-if="loading">
+						Loading attachments...
+						<div class="ms-1 spinner-border spinner-border-sm" role="status">
+							<span class="visually-hidden">Loading...</span>
+						</div>
+					</template>
+					<template v-else-if="attachments">
+						<template v-if="totalAttachments > 0">
+							{{ formatNumber(totalAttachments) }} attachment<template v-if="totalAttachments != 1"
+								>s</template
+							>
+						</template>
+						<template v-else> No attachments </template>
+					</template>
+					<template v-else> Attachments </template>
+				</h4>
+			</div>
+		</div>
+
+		<template v-if="error">
+			<p>Failed to load attachments:</p>
+			<div class="alert alert-warning">
+				{{ error }}
+			</div>
+		</template>
+
+		<template v-else-if="attachments && totalAttachments > 0">
+			<!-- Regular Attachments -->
+			<template v-if="attachments.Attachments.length > 0">
+				<h5 class="mb-3">Attachments</h5>
+				<div v-for="(a, i) in attachments.Attachments" :key="'att' + i" class="card mb-3">
+					<div class="card-header">
+						<i :class="attachmentIcon(a)" class="me-2"></i>
+						<strong>{{ a.FileName }}</strong>
+						<a
+							:href="resolve('/api/v1/message/' + message.ID + '/part/' + a.PartID)"
+							class="btn btn-sm btn-outline-secondary float-end"
+							target="_blank"
+						>
+							<i class="bi bi-download"></i>
+							Download
+						</a>
+					</div>
+					<div class="card-body">
+						<table class="table table-sm table-borderless mb-0">
+							<tbody>
+								<tr>
+									<th class="text-nowrap" style="width: 100px">File Size</th>
+									<td>{{ getFileSize(a.Size) }} ({{ formatNumber(a.Size) }} bytes)</td>
+								</tr>
+								<tr>
+									<th class="text-nowrap">File Type</th>
+									<td>{{ a.ContentType }}</td>
+								</tr>
+								<tr>
+									<th class="text-nowrap">MD5</th>
+									<td>
+										<code class="user-select-all">{{ a.MD5 }}</code>
+										<button
+											class="btn btn-sm btn-link p-0 ms-2"
+											title="Copy MD5"
+											@click="copyToClipboard(a.MD5)"
+										>
+											<i class="bi bi-clipboard"></i>
+										</button>
+									</td>
+								</tr>
+								<tr>
+									<th class="text-nowrap">SHA1</th>
+									<td>
+										<code class="user-select-all">{{ a.SHA1 }}</code>
+										<button
+											class="btn btn-sm btn-link p-0 ms-2"
+											title="Copy SHA1"
+											@click="copyToClipboard(a.SHA1)"
+										>
+											<i class="bi bi-clipboard"></i>
+										</button>
+									</td>
+								</tr>
+								<tr>
+									<th class="text-nowrap">SHA256</th>
+									<td>
+										<code class="user-select-all small">{{ a.SHA256 }}</code>
+										<button
+											class="btn btn-sm btn-link p-0 ms-2"
+											title="Copy SHA256"
+											@click="copyToClipboard(a.SHA256)"
+										>
+											<i class="bi bi-clipboard"></i>
+										</button>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</template>
+
+			<!-- Inline Attachments -->
+			<template v-if="attachments.Inline.length > 0">
+				<h5 class="mb-3 mt-4">Inline Attachments</h5>
+				<div v-for="(a, i) in attachments.Inline" :key="'inline' + i" class="card mb-3">
+					<div class="card-header">
+						<i :class="attachmentIcon(a)" class="me-2"></i>
+						<strong>{{ a.FileName }}</strong>
+						<a
+							:href="resolve('/api/v1/message/' + message.ID + '/part/' + a.PartID)"
+							class="btn btn-sm btn-outline-secondary float-end"
+							target="_blank"
+						>
+							<i class="bi bi-download"></i>
+							Download
+						</a>
+					</div>
+					<div class="card-body">
+						<table class="table table-sm table-borderless mb-0">
+							<tbody>
+								<tr>
+									<th class="text-nowrap" style="width: 100px">File Size</th>
+									<td>{{ getFileSize(a.Size) }} ({{ formatNumber(a.Size) }} bytes)</td>
+								</tr>
+								<tr>
+									<th class="text-nowrap">File Type</th>
+									<td>{{ a.ContentType }}</td>
+								</tr>
+								<tr>
+									<th class="text-nowrap">MD5</th>
+									<td>
+										<code class="user-select-all">{{ a.MD5 }}</code>
+										<button
+											class="btn btn-sm btn-link p-0 ms-2"
+											title="Copy MD5"
+											@click="copyToClipboard(a.MD5)"
+										>
+											<i class="bi bi-clipboard"></i>
+										</button>
+									</td>
+								</tr>
+								<tr>
+									<th class="text-nowrap">SHA1</th>
+									<td>
+										<code class="user-select-all">{{ a.SHA1 }}</code>
+										<button
+											class="btn btn-sm btn-link p-0 ms-2"
+											title="Copy SHA1"
+											@click="copyToClipboard(a.SHA1)"
+										>
+											<i class="bi bi-clipboard"></i>
+										</button>
+									</td>
+								</tr>
+								<tr>
+									<th class="text-nowrap">SHA256</th>
+									<td>
+										<code class="user-select-all small">{{ a.SHA256 }}</code>
+										<button
+											class="btn btn-sm btn-link p-0 ms-2"
+											title="Copy SHA256"
+											@click="copyToClipboard(a.SHA256)"
+										>
+											<i class="bi bi-clipboard"></i>
+										</button>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</template>
+		</template>
+
+		<template v-else-if="attachments && totalAttachments === 0">
+			<p class="text-muted">No attachments were found in this message.</p>
+		</template>
+	</div>
+</template>

--- a/server/ui-src/components/message/MessageItem.vue
+++ b/server/ui-src/components/message/MessageItem.vue
@@ -1,7 +1,9 @@
 <script>
 import Attachments from "./MessageAttachments.vue";
+import AttachmentDetails from "./AttachmentDetails.vue";
 import Headers from "./MessageHeaders.vue";
 import HTMLCheck from "./HTMLCheck.vue";
+import MessageLinks from "./MessageLinks.vue";
 import LinkCheck from "./LinkCheck.vue";
 import SpamAssassin from "./SpamAssassin.vue";
 import Tags from "bootstrap5-tags";
@@ -17,8 +19,10 @@ hljs.registerLanguage("html", xml);
 export default {
 	components: {
 		Attachments,
+		AttachmentDetails,
 		Headers,
 		HTMLCheck,
+		MessageLinks,
 		LinkCheck,
 		SpamAssassin,
 	},
@@ -655,6 +659,34 @@ export default {
 							</span>
 						</button>
 					</li>
+					<li>
+						<button
+							id="nav-attachments-tab"
+							class="dropdown-item"
+							data-bs-toggle="tab"
+							data-bs-target="#nav-attachments"
+							type="button"
+							role="tab"
+							aria-controls="nav-attachments"
+							aria-selected="false"
+						>
+							Attachments
+						</button>
+					</li>
+					<li>
+						<button
+							id="nav-links-tab"
+							class="dropdown-item"
+							data-bs-toggle="tab"
+							data-bs-target="#nav-links"
+							type="button"
+							role="tab"
+							aria-controls="nav-links"
+							aria-selected="false"
+						>
+							Links
+						</button>
+					</li>
 					<li v-if="mailbox.showLinkCheck">
 						<button
 							id="nav-link-check-tab"
@@ -713,6 +745,30 @@ export default {
 				<span v-if="htmlScore !== false" class="badge rounded-pill p-1" :class="htmlScoreColor">
 					<small>{{ Math.floor(htmlScore) }}%</small>
 				</span>
+			</button>
+			<button
+				id="nav-attachments-tab"
+				class="d-none d-xl-inline-block nav-link"
+				data-bs-toggle="tab"
+				data-bs-target="#nav-attachments"
+				type="button"
+				role="tab"
+				aria-controls="nav-attachments"
+				aria-selected="false"
+			>
+				Attachments
+			</button>
+			<button
+				id="nav-links-tab"
+				class="d-none d-xl-inline-block nav-link"
+				data-bs-toggle="tab"
+				data-bs-target="#nav-links"
+				type="button"
+				role="tab"
+				aria-controls="nav-links"
+				aria-selected="false"
+			>
+				Links
 			</button>
 			<button
 				v-if="mailbox.showLinkCheck"
@@ -857,6 +913,18 @@ export default {
 					@set-spam-score="(n) => (spamScore = n)"
 					@set-badge-style="(v) => (spamScoreColor = v)"
 				/>
+			</div>
+			<div
+				id="nav-attachments"
+				class="tab-pane fade"
+				role="tabpanel"
+				aria-labelledby="nav-attachments-tab"
+				tabindex="0"
+			>
+				<AttachmentDetails :message="message" />
+			</div>
+			<div id="nav-links" class="tab-pane fade" role="tabpanel" aria-labelledby="nav-links-tab" tabindex="0">
+				<MessageLinks :message="message" />
 			</div>
 			<div
 				v-if="mailbox.showLinkCheck"

--- a/server/ui-src/components/message/MessageLinks.vue
+++ b/server/ui-src/components/message/MessageLinks.vue
@@ -1,0 +1,115 @@
+<script>
+import axios from "axios";
+import commonMixins from "../../mixins/CommonMixins";
+
+export default {
+	mixins: [commonMixins],
+
+	props: {
+		message: {
+			type: Object,
+			required: true,
+		},
+	},
+
+	data() {
+		return {
+			error: false,
+			links: false,
+			loaded: false,
+			loading: false,
+		};
+	},
+
+	mounted() {
+		this.loadLinks();
+	},
+
+	methods: {
+		copyToClipboard(text) {
+			navigator.clipboard.writeText(text);
+		},
+
+		loadLinks() {
+			this.loading = true;
+			const uri = this.resolve("/api/v1/message/" + this.message.ID + "/links");
+
+			axios
+				.get(uri, null)
+				.then((result) => {
+					this.links = result.data;
+					this.error = false;
+					this.loaded = true;
+				})
+				.catch((error) => {
+					if (error.response && error.response.data) {
+						if (error.response.data.Error) {
+							this.error = error.response.data.Error;
+						} else {
+							this.error = error.response.data;
+						}
+					} else if (error.request) {
+						this.error = "Error sending data to the server. Please try again.";
+					} else {
+						this.error = error.message;
+					}
+				})
+				.then(() => {
+					this.loading = false;
+				});
+		},
+	},
+};
+</script>
+
+<template>
+	<div class="pe-3">
+		<div class="row mb-3 align-items-center">
+			<div class="col">
+				<h4 class="mb-0">
+					<template v-if="loading">
+						Loading links...
+						<div class="ms-1 spinner-border spinner-border-sm" role="status">
+							<span class="visually-hidden">Loading...</span>
+						</div>
+					</template>
+					<template v-else-if="links">
+						<template v-if="links.Total > 0">
+							{{ formatNumber(links.Total) }} link<template v-if="links.Total != 1">s</template>
+						</template>
+						<template v-else> No links detected </template>
+					</template>
+					<template v-else> Links </template>
+				</h4>
+			</div>
+		</div>
+
+		<template v-if="error">
+			<p>Failed to load links:</p>
+			<div class="alert alert-warning">
+				{{ error }}
+			</div>
+		</template>
+
+		<template v-else-if="links && links.Total > 0">
+			<div class="card">
+				<ul class="list-group list-group-flush">
+					<li v-for="(url, i) in links.Links" :key="'link' + i" class="list-group-item">
+						<a :href="url" target="_blank" class="no-icon">{{ url }}</a>
+						<button
+							class="btn btn-sm btn-link p-0 ms-2"
+							title="Copy link"
+							@click="copyToClipboard(url)"
+						>
+							<i class="bi bi-clipboard"></i>
+						</button>
+					</li>
+				</ul>
+			</div>
+		</template>
+
+		<template v-else-if="links && links.Total === 0">
+			<p class="text-muted">No links were found in this message.</p>
+		</template>
+	</div>
+</template>


### PR DESCRIPTION
We are dealing with lots of attachments and links, so added this quality of life improvement.

Add two new tabs before "Link Check":
- Attachments: displays file size, content type, MD5, SHA1, SHA256 hashes with copy-to-clipboard buttons for each hash
- Links: lists all unique links extracted from message HTML/text with copy-to-clipboard buttons

Backend changes:
- Add ExtractLinks() function to linkcheck package
- Add /api/v1/message/{id}/links endpoint
- Add /api/v1/message/{id}/attachments endpoint with hash computation

Frontend changes:
- Add AttachmentDetails.vue component
- Add MessageLinks.vue component
- Update MessageItem.vue with new tab buttons and panes

--- 

<img width="1280" height="624" alt="SCR-20260122-lxwm" src="https://github.com/user-attachments/assets/2799cd8c-bd76-4e7b-901d-bf30721f765d" />

--- 

<img width="973" height="408" alt="SCR-20260122-lxzp" src="https://github.com/user-attachments/assets/b43d780e-ad08-4a3a-86a2-e6901eea4049" />




