### PR TITLE
Fix: Update install instructions when setting INSTALL_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ sudo sh < <(curl -sL https://raw.githubusercontent.com/axllent/mailpit/develop/i
 You can also change the install path to something else by setting the `INSTALL_PATH` environment, for example:
 
 ```shell
-INSTALL_PATH=/usr/bin sudo sh < <(curl -sL https://raw.githubusercontent.com/axllent/mailpit/develop/install.sh)
+sudo INSTALL_PATH=/usr/bin sh < <(curl -sL https://raw.githubusercontent.com/axllent/mailpit/develop/install.sh)
 ```
 
 


### PR DESCRIPTION
The environment will not pass through sudo by default
```
$ INSTALL_PATH=/usr/bin sudo sh < <(curl -sL https://raw.githubusercontent.com/axllent/mailpit/develop/install.sh)
Installed successfully to "/usr/local/bin/mailpit".

$ sudo INSTALL_PATH=/usr/bin sh < <(curl -sL https://raw.githubusercontent.com/axllent/mailpit/develop/install.sh)
Installed successfully to "/usr/bin/mailpit".
```