### PR TITLE
Prevent flashing during async message transitions

### DIFF
--- a/server/ui-src/assets/styles.scss
+++ b/server/ui-src/assets/styles.scss
@@ -80,9 +80,9 @@
 	.loader-bar {
 		width: 35%;
 		height: 4px;
-		background: $primary;
+		background: $warning;
 		border-radius: 0 999px 999px 0;
-		box-shadow: 0 0 10px rgba($primary, 0.35);
+		box-shadow: 0 0 10px rgba($warning, 0.45);
 		animation: loader-slide 1.2s ease-in-out infinite;
 	}
 }
@@ -105,7 +105,7 @@
 @include color-mode(dark) {
 	.loader {
 		.loader-bar {
-			box-shadow: 0 0 12px rgba($primary, 0.5);
+			box-shadow: 0 0 12px rgba($warning, 0.55);
 		}
 	}
 

--- a/server/ui-src/assets/styles.scss
+++ b/server/ui-src/assets/styles.scss
@@ -74,15 +74,39 @@
 	top: 0;
 	left: 0;
 	width: 100%;
-	height: 100%;
-	background: rgba(255, 255, 255, 0.4);
 	z-index: 1500;
+	pointer-events: none;
+
+	.loader-bar {
+		width: 35%;
+		height: 4px;
+		background: $primary;
+		border-radius: 0 999px 999px 0;
+		box-shadow: 0 0 10px rgba($primary, 0.35);
+		animation: loader-slide 1.2s ease-in-out infinite;
+	}
+}
+
+@keyframes loader-slide {
+	0% {
+		transform: translateX(-100%);
+	}
+
+	50% {
+		transform: translateX(110vw);
+	}
+
+	100% {
+		transform: translateX(110vw);
+	}
 }
 
 // dark mode adjustments
 @include color-mode(dark) {
 	.loader {
-		background: rgba(0, 0, 0, 0.4);
+		.loader-bar {
+			box-shadow: 0 0 12px rgba($primary, 0.5);
+		}
 	}
 
 	.token.tag,

--- a/server/ui-src/components/AjaxLoader.vue
+++ b/server/ui-src/components/AjaxLoader.vue
@@ -6,11 +6,50 @@ export default {
 			default: 0,
 		},
 	},
+
+	data() {
+		return {
+			isVisible: false,
+			showTimer: null,
+		};
+	},
+
+	watch: {
+		loading: {
+			immediate: true,
+			handler(v) {
+				if (v > 0) {
+					if (this.isVisible || this.showTimer) {
+						return;
+					}
+
+					this.showTimer = window.setTimeout(() => {
+						this.isVisible = this.loading > 0;
+						this.showTimer = null;
+					}, 200);
+					return;
+				}
+
+				if (this.showTimer) {
+					window.clearTimeout(this.showTimer);
+					this.showTimer = null;
+				}
+
+				this.isVisible = false;
+			},
+		},
+	},
+
+	beforeUnmount() {
+		if (this.showTimer) {
+			window.clearTimeout(this.showTimer);
+		}
+	},
 };
 </script>
 
 <template>
-	<div v-if="loading > 0" class="loader" role="status" aria-live="polite" aria-label="Loading">
+	<div v-if="isVisible" class="loader" role="status" aria-live="polite" aria-label="Loading">
 		<div class="loader-bar"></div>
 	</div>
 </template>

--- a/server/ui-src/components/AjaxLoader.vue
+++ b/server/ui-src/components/AjaxLoader.vue
@@ -10,11 +10,7 @@ export default {
 </script>
 
 <template>
-	<div v-if="loading > 0" class="loader">
-		<div class="d-flex justify-content-center align-items-center h-100">
-			<div class="spinner-border text-muted" role="status">
-				<span class="visually-hidden">Loading...</span>
-			</div>
-		</div>
+	<div v-if="loading > 0" class="loader" role="status" aria-live="polite" aria-label="Loading">
+		<div class="loader-bar"></div>
 	</div>
 </template>

--- a/server/ui-src/components/message/HTMLCheck.vue
+++ b/server/ui-src/components/message/HTMLCheck.vue
@@ -194,7 +194,6 @@ export default {
 	watch: {
 		message: {
 			handler() {
-				this.$emit("setHtmlScore", false);
 				this.doCheck();
 			},
 			deep: true,

--- a/server/ui-src/components/message/MessageItem.vue
+++ b/server/ui-src/components/message/MessageItem.vue
@@ -129,8 +129,6 @@ export default {
 		message() {
 			this.messageTags = this.message.Tags;
 			this.loadHeaders = false;
-			this.htmlScore = false;
-			this.htmlScoreColor = false;
 			this.linkCheckErrors = false;
 			this.spamScore = false;
 			this.spamScoreColor = false;

--- a/server/ui-src/components/message/MessageItem.vue
+++ b/server/ui-src/components/message/MessageItem.vue
@@ -126,6 +126,28 @@ export default {
 			}
 		},
 
+		message() {
+			this.messageTags = this.message.Tags;
+			this.loadHeaders = false;
+			this.htmlScore = false;
+			this.htmlScoreColor = false;
+			this.linkCheckErrors = false;
+			this.spamScore = false;
+			this.spamScoreColor = false;
+
+			const rawTab = document.getElementById("nav-raw-tab");
+			if (rawTab?.classList.contains("active")) {
+				this.srcURI = this.resolve("/api/v1/message/" + this.message.ID + "/raw");
+			} else {
+				this.srcURI = false;
+			}
+
+			this.$nextTick(() => {
+				this.isHTMLTabSelected();
+				this.resizeIFrames();
+			});
+		},
+
 		scaleHTMLPreview(v) {
 			if (v === "display") {
 				window.setTimeout(() => {

--- a/server/ui-src/views/MessageView.vue
+++ b/server/ui-src/views/MessageView.vue
@@ -134,7 +134,6 @@ export default {
 
 	methods: {
 		loadMessage() {
-			this.message = false;
 			const uri = this.resolve("/api/v1/message/" + this.$route.params.id);
 			this.get(
 				uri,
@@ -712,7 +711,7 @@ export default {
 						{{ errorMessage }}
 					</h3>
 				</template>
-				<Message v-else-if="message" :key="message.ID" :message="message" />
+				<Message v-else-if="message" :message="message" />
 			</div>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary
- replace the full-screen loading overlay with a fixed top loading bar
- keep the message view mounted while loading the next message
- stop remounting the HTML preview subtree on message-to-message navigation

## Testing
- npm run lint
- npm run package
- rebuilt the Docker image and verified the local container was healthy on :8025