### PR TITLE
Add wait support to mailpit readyz

### DIFF
--- a/cmd/readyz.go
+++ b/cmd/readyz.go
@@ -14,7 +14,10 @@ import (
 )
 
 var (
-	useHTTPS bool
+	useHTTPS        bool
+	readyzWait      bool
+	readyzTimeout   time.Duration
+	readyzPollEvery = time.Second
 )
 
 // readyzCmd represents the healthcheck command
@@ -47,11 +50,49 @@ settings to determine the HTTP bind interface & port.
 		}
 		client := &http.Client{Transport: conf}
 
-		res, err := client.Get(uri)
-		if err != nil || res.StatusCode != 200 {
+		if readyzWait {
+			if err := waitForReady(client, uri, readyzTimeout); err != nil {
+				fmt.Fprintln(os.Stderr, err)
+				os.Exit(1)
+			}
+			return
+		}
+
+		if err := checkReady(client, uri); err != nil {
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 	},
+}
+
+func checkReady(client *http.Client, uri string) error {
+	res, err := client.Get(uri)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status: %s", res.Status)
+	}
+
+	return nil
+}
+
+func waitForReady(client *http.Client, uri string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		if err := checkReady(client, uri); err == nil {
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out after %s waiting for Mailpit to become ready", timeout)
+		}
+
+		time.Sleep(readyzPollEvery)
+	}
 }
 
 func init() {
@@ -74,4 +115,6 @@ func init() {
 	readyzCmd.Flags().StringVarP(&config.HTTPListen, "listen", "l", config.HTTPListen, "Set the HTTP bind interface & port")
 	readyzCmd.Flags().StringVar(&config.Webroot, "webroot", config.Webroot, "Set the webroot for web UI & API")
 	readyzCmd.Flags().BoolVar(&useHTTPS, "https", useHTTPS, "Connect via HTTPS (ignores HTTPS validation)")
+	readyzCmd.Flags().BoolVar(&readyzWait, "wait", readyzWait, "Wait until Mailpit is ready instead of checking once")
+	readyzCmd.Flags().DurationVar(&readyzTimeout, "timeout", 30*time.Second, "Maximum time to wait when --wait is set")
 }

--- a/cmd/readyz_test.go
+++ b/cmd/readyz_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestCheckReady(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := checkReady(srv.Client(), srv.URL); err != nil {
+		t.Fatalf("checkReady() error = %v", err)
+	}
+}
+
+func TestWaitForReadyRetriesUntilSuccess(t *testing.T) {
+	oldPoll := readyzPollEvery
+	readyzPollEvery = time.Millisecond
+	t.Cleanup(func() { readyzPollEvery = oldPoll })
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := waitForReady(srv.Client(), srv.URL, 100*time.Millisecond); err != nil {
+		t.Fatalf("waitForReady() error = %v", err)
+	}
+
+	if calls < 2 {
+		t.Fatalf("waitForReady() calls = %d, want at least 2", calls)
+	}
+}
+
+func TestWaitForReadyTimesOut(t *testing.T) {
+	oldPoll := readyzPollEvery
+	readyzPollEvery = time.Millisecond
+	t.Cleanup(func() { readyzPollEvery = oldPoll })
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(srv.Close)
+
+	if err := waitForReady(srv.Client(), srv.URL, 5*time.Millisecond); err == nil {
+		t.Fatal("waitForReady() error = nil, want timeout")
+	}
+
+	if calls == 0 {
+		t.Fatal("waitForReady() did not call the endpoint")
+	}
+}


### PR DESCRIPTION
- Add `--wait` and `--timeout` to `mailpit readyz` for scriptable readiness checks.
- Retry `/readyz` until it succeeds or times out, and print failures to stderr.
- Add focused tests for immediate success, retry, and timeout behavior.
