### PR TITLE
Feature: base docker image on distroless debian13, nonroot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN  apk upgrade && apk add git npm && \
 npm ci && npm run package && \
 CGO_ENABLED=0 go build -ldflags "-s -w -X github.com/axllent/mailpit/config.Version=${VERSION}" -o /mailpit
 
-FROM alpine:latest
+FROM gcr.io/distroless/static-debian13:nonroot
 
 LABEL org.opencontainers.image.title="Mailpit" \
   org.opencontainers.image.description="An email and SMTP testing tool with API for developers" \
@@ -20,8 +20,6 @@ LABEL org.opencontainers.image.title="Mailpit" \
   org.opencontainers.image.licenses="MIT"
 
 COPY --from=builder /mailpit /mailpit
-
-RUN apk upgrade --no-cache && apk add --no-cache tzdata
 
 EXPOSE 1025/tcp 1110/tcp 8025/tcp
 


### PR DESCRIPTION
Shaves off 14MB (a third) of the image size, gets rid of unnecessary distro features.

There doesn't appear to be a reason to run the daemon as root in the container either, so go with the nonroot variant.

https://github.com/GoogleContainerTools/distroless#why-should-i-use-distroless-images

The static-debian13 image does contain tzdata -- I'm assuming that's needed as it was explicitly installed before. (In absence of shell, image contents can be examined for example with https://github.com/wagoodman/dive)

Caveat: _very_ lightly tested.