### PR TITLE
Namespace theme switcher local storage key

### DIFF
--- a/server/ui-src/components/AppSettings.vue
+++ b/server/ui-src/components/AppSettings.vue
@@ -10,7 +10,7 @@ export default {
 	data() {
 		return {
 			mailbox,
-			theme: localStorage.getItem("theme") ? localStorage.getItem("theme") : "auto",
+			theme: localStorage.getItem("mailpit-theme") ? localStorage.getItem("mailpit-theme") : "auto",
 			timezones,
 			chaosConfig: false,
 			chaosUpdated: false,
@@ -21,9 +21,9 @@ export default {
 	watch: {
 		theme(v) {
 			if (v === "auto") {
-				localStorage.removeItem("theme");
+				localStorage.removeItem("mailpit-theme");
 			} else {
-				localStorage.setItem("theme", v);
+				localStorage.setItem("mailpit-theme", v);
 			}
 			this.setTheme();
 		},


### PR DESCRIPTION
**Overview**

Mailpit uses "theme" for its theme switcher's local storage key. This is generic and can conflict with other applications' theme switchers when hosted on the same domain (e.g., Playwright).

**Changes**

This PR renames the localStorage key to `mailpit-theme` to prevent conflicts. No other functionality is changed.

**Migration**

A migration path was intentionally omitted. Users who currently have a non-default theme configured with the `theme` key will need to reset their theme after upgrading.