### PR TITLE
Add support for separate mailboxes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ including image thumbnails), including optional [HTTPS](https://mailpit.axllent.
 - [Create screenshots](https://mailpit.axllent.org/docs/usage/html-screenshots/) of HTML messages via web UI
 - Mobile and tablet HTML preview toggle in desktop mode
 - [Message tagging](https://mailpit.axllent.org/docs/usage/tagging/) including manual tagging or automated tagging using filtering and "plus addressing"
-- [Separate mailboxes](#separate-mailboxes-per-smtp-user) - when SMTP authentication is enabled, each authenticated username becomes its own switchable mailbox in the web UI
+- [Separate mailboxes](https://mailpit.axllent.org/docs/usage/mailboxes/) - when SMTP authentication is enabled, each authenticated username becomes its own switchable mailbox in the web UI
 - [SMTP relaying](https://mailpit.axllent.org/docs/configuration/smtp-relay/) (message release) - relay messages via a different SMTP server including an optional allowlist of accepted recipients
 - [SMTP forwarding](https://mailpit.axllent.org/docs/configuration/smtp-forward/) - automatically forward messages via a different SMTP server to predefined email addresses
 - Fast message [storing & processing](https://mailpit.axllent.org/docs/configuration/email-storage/) - ingesting 200-300 emails per second over SMTP depending on CPU, network speed & email size,
@@ -116,52 +116,6 @@ Please refer to [the documentation](https://mailpit.axllent.org/docs/install/tes
 Mailpit's SMTP server (default on port 1025), so you will likely need to configure your sending application to deliver mail via that port. 
 A common MTA (Mail Transfer Agent) that delivers system emails to an SMTP server is `sendmail`, used by many applications, including PHP. 
 Mailpit can also act as substitute for sendmail. For instructions on how to set this up, please refer to the [sendmail documentation](https://mailpit.axllent.org/docs/install/sendmail/).
-
-
-### Separate mailboxes per SMTP user
-
-Mailpit stores all received mail in a single database, but when **SMTP authentication** is enabled it records the authenticated username on every message. Each distinct username then appears as its own **mailbox** in the web UI, so you can point several services at the same Mailpit instance and view each one's mail separately.
-
-#### 1. Create SMTP credentials (one per service)
-
-Credentials use the [htpasswd](https://httpd.apache.org/docs/current/programs/htpasswd.html) format — one `username:password` pair per line. Give each service its own username:
-
-```
-service-a:$2y$...bcrypt-hash...
-service-b:$2y$...bcrypt-hash...
-```
-
-Generate a bcrypt entry for each user with `htpasswd`:
-
-```shell
-htpasswd -bnBC 10 service-a "s3cret-a" >> smtp-auth.txt
-htpasswd -bnBC 10 service-b "s3cret-b" >> smtp-auth.txt
-```
-
-#### 2. Start Mailpit with the credentials
-
-```shell
-mailpit --smtp-auth-file ./smtp-auth.txt
-```
-
-The equivalent environment variables are `MP_SMTP_AUTH_FILE` (a file path) or `MP_SMTP_AUTH` (the credentials inline).
-
-> For local testing you can use plaintext `username:password` credentials by also passing `--smtp-auth-allow-insecure` (or `MP_SMTP_AUTH_ALLOW_INSECURE=true`). Do not use plaintext credentials in production.
-
-#### 3. Point each service at its own username
-
-Configure each application to authenticate with its own credentials, for example:
-
-```
-MAIL_HOST=<mailpit-host>
-MAIL_PORT=1025
-MAIL_USERNAME=service-a
-MAIL_PASSWORD=s3cret-a
-```
-
-Once each service has sent mail, use the **Mailbox** dropdown in the web UI sidebar to switch between `All mail` and each service.
-
-> Enabling SMTP authentication means **all** senders must authenticate — unauthenticated mail is rejected. With `--smtp-auth-accept-any`, any username is accepted **without a password check**, so mail is filed under whatever mailbox name the sender claims — convenient for local testing, but the mailbox label can't be trusted.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ including image thumbnails), including optional [HTTPS](https://mailpit.axllent.
 - [Create screenshots](https://mailpit.axllent.org/docs/usage/html-screenshots/) of HTML messages via web UI
 - Mobile and tablet HTML preview toggle in desktop mode
 - [Message tagging](https://mailpit.axllent.org/docs/usage/tagging/) including manual tagging or automated tagging using filtering and "plus addressing"
+- [Separate mailboxes](#separate-mailboxes-per-smtp-user) - when SMTP authentication is enabled, each authenticated username becomes its own switchable mailbox in the web UI
 - [SMTP relaying](https://mailpit.axllent.org/docs/configuration/smtp-relay/) (message release) - relay messages via a different SMTP server including an optional allowlist of accepted recipients
 - [SMTP forwarding](https://mailpit.axllent.org/docs/configuration/smtp-forward/) - automatically forward messages via a different SMTP server to predefined email addresses
 - Fast message [storing & processing](https://mailpit.axllent.org/docs/configuration/email-storage/) - ingesting 200-300 emails per second over SMTP depending on CPU, network speed & email size,
@@ -115,6 +116,52 @@ Please refer to [the documentation](https://mailpit.axllent.org/docs/install/tes
 Mailpit's SMTP server (default on port 1025), so you will likely need to configure your sending application to deliver mail via that port. 
 A common MTA (Mail Transfer Agent) that delivers system emails to an SMTP server is `sendmail`, used by many applications, including PHP. 
 Mailpit can also act as substitute for sendmail. For instructions on how to set this up, please refer to the [sendmail documentation](https://mailpit.axllent.org/docs/install/sendmail/).
+
+
+### Separate mailboxes per SMTP user
+
+Mailpit stores all received mail in a single database, but when **SMTP authentication** is enabled it records the authenticated username on every message. Each distinct username then appears as its own **mailbox** in the web UI, so you can point several services at the same Mailpit instance and view each one's mail separately.
+
+#### 1. Create SMTP credentials (one per service)
+
+Credentials use the [htpasswd](https://httpd.apache.org/docs/current/programs/htpasswd.html) format — one `username:password` pair per line. Give each service its own username:
+
+```
+service-a:$2y$...bcrypt-hash...
+service-b:$2y$...bcrypt-hash...
+```
+
+Generate a bcrypt entry for each user with `htpasswd`:
+
+```shell
+htpasswd -bnBC 10 service-a "s3cret-a" >> smtp-auth.txt
+htpasswd -bnBC 10 service-b "s3cret-b" >> smtp-auth.txt
+```
+
+#### 2. Start Mailpit with the credentials
+
+```shell
+mailpit --smtp-auth-file ./smtp-auth.txt
+```
+
+The equivalent environment variables are `MP_SMTP_AUTH_FILE` (a file path) or `MP_SMTP_AUTH` (the credentials inline).
+
+> For local testing you can use plaintext `username:password` credentials by also passing `--smtp-auth-allow-insecure` (or `MP_SMTP_AUTH_ALLOW_INSECURE=true`). Do not use plaintext credentials in production.
+
+#### 3. Point each service at its own username
+
+Configure each application to authenticate with its own credentials, for example:
+
+```
+MAIL_HOST=<mailpit-host>
+MAIL_PORT=1025
+MAIL_USERNAME=service-a
+MAIL_PASSWORD=s3cret-a
+```
+
+Once each service has sent mail, use the **Mailbox** dropdown in the web UI sidebar to switch between `All mail` and each service.
+
+> Enabling SMTP authentication means **all** senders must authenticate — unauthenticated mail is rejected. With `--smtp-auth-accept-any`, any username is accepted **without a password check**, so mail is filed under whatever mailbox name the sender claims — convenient for local testing, but the mailbox label can't be trusted.
 
 ---
 

--- a/internal/storage/database.go
+++ b/internal/storage/database.go
@@ -193,17 +193,19 @@ func Ping() error {
 // StatsGet returns the total/unread statistics for a mailbox
 func StatsGet() MailboxStats {
 	var (
-		total  = CountTotal()
-		unread = CountUnread()
-		tags   = GetAllTags()
+		total     = CountTotal()
+		unread    = CountUnread()
+		tags      = GetAllTags()
+		usernames = GetAllUsernames()
 	)
 
 	dbLastAction = time.Now()
 
 	return MailboxStats{
-		Total:  total,
-		Unread: unread,
-		Tags:   tags,
+		Total:     total,
+		Unread:    unread,
+		Tags:      tags,
+		Usernames: usernames,
 	}
 }
 

--- a/internal/storage/search.go
+++ b/internal/storage/search.go
@@ -434,6 +434,15 @@ func searchQueryBuilder(searchString, timezone string) *sqlf.Stmt {
 					q.Where(`m.ID IN (SELECT mt.ID FROM `+tenant("message_tags")+` mt JOIN `+tenant("tags")+` t ON mt.TagID = t.ID WHERE t.Name = ?)`, w)
 				}
 			}
+		} else if strings.HasPrefix(lw, "username:") {
+			w = cleanString(w[9:])
+			if w != "" {
+				if exclude {
+					q.Where(`IFNULL(json_extract(m.Metadata, '$.Username'), '') != ?`, w)
+				} else {
+					q.Where(`json_extract(m.Metadata, '$.Username') = ?`, w)
+				}
+			}
 		} else if lw == "is:read" {
 			if exclude {
 				q.Where("Read = 0")

--- a/internal/storage/structs.go
+++ b/internal/storage/structs.go
@@ -111,9 +111,10 @@ type MessageSummary struct {
 
 // MailboxStats struct for quick mailbox total/read lookups
 type MailboxStats struct {
-	Total  uint64
-	Unread uint64
-	Tags   []string
+	Total     uint64
+	Unread    uint64
+	Tags      []string
+	Usernames []string
 }
 
 // Metadata struct for storing message metadata

--- a/internal/storage/usernames.go
+++ b/internal/storage/usernames.go
@@ -1,0 +1,31 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/axllent/mailpit/internal/logger"
+	"github.com/leporo/sqlf"
+)
+
+// GetAllUsernames returns all distinct SMTP/Send-API authentication usernames
+// currently in use, sorted alphabetically. Messages received without
+// authentication (blank username) are excluded.
+func GetAllUsernames() []string {
+	var usernames = []string{}
+	var name string
+
+	if err := sqlf.
+		Select(`DISTINCT json_extract(Metadata, '$.Username')`).To(&name).
+		From(tenant("mailbox")).
+		Where(`json_extract(Metadata, '$.Username') IS NOT NULL`).
+		Where(`json_extract(Metadata, '$.Username') != ''`).
+		OrderBy(`json_extract(Metadata, '$.Username')`).
+		QueryAndClose(context.TODO(), db, func(_ *sql.Rows) {
+			usernames = append(usernames, name)
+		}); err != nil {
+		logger.Log().Errorf("[db] %s", err.Error())
+	}
+
+	return usernames
+}

--- a/internal/storage/usernames_test.go
+++ b/internal/storage/usernames_test.go
@@ -1,0 +1,141 @@
+package storage
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/axllent/mailpit/config"
+	"github.com/jhillyerd/enmime/v2"
+)
+
+// storeWithUsername stores a simple message optionally authenticated as username.
+func storeWithUsername(t *testing.T, i int, username *string) {
+	t.Helper()
+
+	msg := enmime.Builder().
+		From(fmt.Sprintf("From %d", i), fmt.Sprintf("from-%d@example.com", i)).
+		To("Inbox", "inbox@example.com").
+		Subject(fmt.Sprintf("Message %d", i)).
+		Text([]byte("This is the email body"))
+
+	env, err := msg.Build()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buf := new(bytes.Buffer)
+	if err := env.Encode(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	b := buf.Bytes()
+	if _, err := Store(&b, username); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestUsernameSearch verifies the `username:` search filter that backs the
+// per-username mailbox views.
+func TestUsernameSearch(t *testing.T) {
+	for _, tenantID := range []string{"", "MyServer 3", "host.example.com"} {
+		tenantID = config.DBTenantID(tenantID)
+		setup(tenantID)
+
+		serviceA := "service-a"
+		serviceB := "service-b"
+
+		// 3 authenticated as service-a, 2 as service-b, 1 unauthenticated
+		for i := range 3 {
+			storeWithUsername(t, i, &serviceA)
+		}
+		for i := range 2 {
+			storeWithUsername(t, i, &serviceB)
+		}
+		storeWithUsername(t, 0, nil)
+
+		// username:service-a -> exactly the 3 service-a messages
+		res, total, err := Search("username:service-a", "", 0, 0, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, len(res), 3, "username:service-a result count")
+		assertEqual(t, total, 3, "username:service-a total")
+		for _, m := range res {
+			assertEqual(t, m.Username, "service-a", "returned message username should match")
+		}
+
+		// username:service-b -> exactly the 2 service-b messages
+		res, _, err = Search("username:service-b", "", 0, 0, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, len(res), 2, "username:service-b result count")
+
+		// exclusion: everything that is NOT service-a (2 service-b + 1 unauthenticated)
+		res, _, err = Search("-username:service-a", "", 0, 0, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, len(res), 3, "-username:service-a result count")
+		for _, m := range res {
+			if m.Username == "service-a" {
+				t.Fatal("excluded username should not be present in -username:service-a results")
+			}
+		}
+
+		// exact match only: a prefix must not match a longer username
+		res, _, err = Search("username:service", "", 0, 0, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, len(res), 0, "username: should be an exact match, not a prefix")
+
+		// unknown username returns nothing
+		res, _, err = Search("username:does-not-exist", "", 0, 0, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, len(res), 0, "unknown username result count")
+
+		// composes with other filters (mailbox + tag/subject scenario)
+		res, _, err = Search("username:service-a subject:\"Message 0\"", "", 0, 0, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertEqual(t, len(res), 1, "username composed with subject result count")
+
+		Close()
+	}
+}
+
+// TestGetAllUsernames verifies the distinct-username listing used to populate
+// the mailbox switcher.
+func TestGetAllUsernames(t *testing.T) {
+	for _, tenantID := range []string{"", "host.example.com"} {
+		tenantID = config.DBTenantID(tenantID)
+		setup(tenantID)
+
+		// empty to start
+		assertEqual(t, len(GetAllUsernames()), 0, "no usernames expected on empty mailbox")
+
+		serviceA := "service-a"
+		serviceB := "service-b"
+
+		storeWithUsername(t, 0, &serviceA)
+		storeWithUsername(t, 1, &serviceA) // duplicate username
+		storeWithUsername(t, 2, &serviceB)
+		storeWithUsername(t, 3, nil) // unauthenticated -> excluded
+
+		got := GetAllUsernames()
+		assertEqual(t, len(got), 2, "distinct username count")
+		// results are ordered alphabetically
+		assertEqual(t, got[0], "service-a", "first username (sorted)")
+		assertEqual(t, got[1], "service-b", "second username (sorted)")
+
+		// also surfaced through StatsGet for the API/UI
+		assertEqual(t, len(StatsGet().Usernames), 2, "StatsGet usernames count")
+
+		Close()
+	}
+}

--- a/server/apiv1/messages.go
+++ b/server/apiv1/messages.go
@@ -34,6 +34,9 @@ type MessagesSummary struct {
 	// All current tags
 	Tags []string `json:"tags"`
 
+	// All current authentication usernames (SMTP / Send API) in use
+	Usernames []string `json:"usernames"`
+
 	// Messages summary
 	// in: body
 	Messages []storage.MessageSummary `json:"messages"`
@@ -74,6 +77,7 @@ func GetMessages(w http.ResponseWriter, r *http.Request) {
 	res.Total = stats.Total
 	res.Unread = stats.Unread
 	res.Tags = stats.Tags
+	res.Usernames = stats.Usernames
 	res.MessagesCount = stats.Total
 	res.MessagesUnreadCount = stats.Unread
 
@@ -247,6 +251,7 @@ func Search(w http.ResponseWriter, r *http.Request) {
 	res.MessagesCount = tools.SafeUint64(results)
 	res.Unread = stats.Unread
 	res.Tags = stats.Tags
+	res.Usernames = stats.Usernames
 
 	unread, err := storage.SearchUnreadCount(search, r.URL.Query().Get("tz"), beforeTS)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -99,6 +99,8 @@ func Listen() {
 	r.HandleFunc("GET "+config.Webroot+"view/", middleWareFunc(viewHandler))
 
 	r.Handle("GET "+config.Webroot+"search", middleWareFunc(index))
+	// per-username mailbox view (client-side route) served via the same virtual index
+	r.Handle("GET "+config.Webroot+"mailbox/{username}", middleWareFunc(index))
 	// Exact-match the webroot; stdlib "/" is always a subtree so we guard inside.
 	r.HandleFunc("GET "+config.Webroot, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != config.Webroot {

--- a/server/ui-src/components/ListMessages.vue
+++ b/server/ui-src/components/ListMessages.vue
@@ -114,7 +114,8 @@ export default {
 				p.limit = pagination.limit.toString();
 			}
 			const params = new URLSearchParams(p);
-			return "/search?" + params.toString();
+			// stay inside the current username mailbox when one is selected
+			return (this.mailboxBasePath() || "/search") + "?" + params.toString();
 		},
 	},
 };

--- a/server/ui-src/components/NavTags.vue
+++ b/server/ui-src/components/NavTags.vue
@@ -48,15 +48,18 @@ export default {
 
 			query = query.trim();
 
+			// stay inside the current username mailbox when one is selected
+			const base = this.mailboxBasePath();
+
 			if (query === "") {
-				this.$router.push("/");
+				this.$router.push(base || "/");
 			} else {
 				const params = new URLSearchParams({
 					q: query,
 					start: pagination.start.toString(),
 					limit: pagination.limit.toString(),
 				});
-				this.$router.push("/search?" + params.toString());
+				this.$router.push((base || "/search") + "?" + params.toString());
 			}
 		},
 
@@ -71,7 +74,8 @@ export default {
 				p.limit = pagination.limit.toString();
 			}
 			const params = new URLSearchParams(p);
-			return "/search?" + params.toString();
+			// stay inside the current username mailbox when one is selected
+			return (this.mailboxBasePath() || "/search") + "?" + params.toString();
 		},
 	},
 };

--- a/server/ui-src/components/NavUsernames.vue
+++ b/server/ui-src/components/NavUsernames.vue
@@ -1,0 +1,77 @@
+<script>
+import CommonMixins from "../mixins/CommonMixins";
+import { mailbox } from "../stores/mailbox";
+import { pagination } from "../stores/pagination";
+
+export default {
+	mixins: [CommonMixins],
+
+	data() {
+		return {
+			mailbox,
+			pagination,
+		};
+	},
+
+	computed: {
+		// the username mailbox currently being viewed, or "" for All mail
+		current() {
+			return this.$route.name === "mailbox" ? this.$route.params.username : "";
+		},
+	},
+
+	methods: {
+		isActive(username) {
+			return this.current === username;
+		},
+
+		selectMailbox() {
+			// switching mailbox starts a fresh view (clears any within-mailbox filter)
+			pagination.start = 0;
+			this.hideNav();
+		},
+	},
+};
+</script>
+
+<template>
+	<template v-if="mailbox.usernames && mailbox.usernames.length">
+		<div class="mt-4 text-muted">
+			<small class="text-uppercase">Mailbox</small>
+		</div>
+		<div class="dropdown mt-1 mb-2">
+			<button
+				class="btn btn-outline-secondary btn-sm dropdown-toggle w-100 d-flex justify-content-between align-items-center"
+				type="button"
+				data-bs-toggle="dropdown"
+				aria-expanded="false"
+			>
+				<span class="text-truncate">
+					<i class="bi bi-inbox-fill me-1"></i>
+					<template v-if="current">{{ current }}</template>
+					<template v-else>All mail</template>
+				</span>
+			</button>
+			<ul class="dropdown-menu w-100">
+				<li>
+					<RouterLink to="/" class="dropdown-item" :class="!current ? 'active' : ''" @click="selectMailbox">
+						<i class="bi bi-inboxes-fill me-1"></i>
+						All mail
+					</RouterLink>
+				</li>
+				<li><hr class="dropdown-divider" /></li>
+				<li v-for="username in mailbox.usernames" :key="username">
+					<RouterLink
+						:to="'/mailbox/' + encodeURIComponent(username)"
+						class="dropdown-item"
+						:class="isActive(username) ? 'active' : ''"
+						@click="selectMailbox"
+					>
+						<i class="bi bi-inbox me-1"></i>
+						{{ username }}
+					</RouterLink>
+				</li>
+			</ul>
+		</div>
+	</template>
+</template>

--- a/server/ui-src/components/SearchForm.vue
+++ b/server/ui-src/components/SearchForm.vue
@@ -31,8 +31,10 @@ export default {
 
 		doSearch(e) {
 			pagination.start = 0;
+			// when scoped to a username mailbox, keep searches inside that mailbox
+			const base = this.mailboxBasePath();
 			if (this.search === "") {
-				this.$router.push("/");
+				this.$router.push(base || "/");
 			} else {
 				const urlParams = new URLSearchParams(window.location.search);
 				const curr = urlParams.get("q");
@@ -51,7 +53,7 @@ export default {
 				}
 
 				const params = new URLSearchParams(p);
-				this.$router.push("/search?" + params.toString());
+				this.$router.push((base || "/search") + "?" + params.toString());
 			}
 
 			e.preventDefault();
@@ -59,7 +61,8 @@ export default {
 
 		resetSearch() {
 			this.search = "";
-			this.$router.push("/");
+			// clearing a search inside a mailbox keeps you in that mailbox
+			this.$router.push(this.mailboxBasePath() || "/");
 		},
 	},
 };

--- a/server/ui-src/mixins/CommonMixins.js
+++ b/server/ui-src/mixins/CommonMixins.js
@@ -67,7 +67,28 @@ export default {
 			return encodeURIComponent(`tag:${tag}`);
 		},
 
+		// base router path for searches/tags in the current context:
+		// a /mailbox/:username scope keeps you inside that mailbox, otherwise null (global)
+		mailboxBasePath() {
+			if (this.$route?.name === "mailbox" && this.$route.params.username) {
+				return "/mailbox/" + encodeURIComponent(this.$route.params.username);
+			}
+			return null;
+		},
+
 		getSearch() {
+			// a dedicated /mailbox/:username view behaves as an implicit
+			// `username:<name>` search so scoped actions (delete/mark read) apply
+			// only to that mailbox, composed with any within-mailbox tag/search (?q=)
+			if (this.$route?.name === "mailbox" && this.$route.params.username) {
+				let u = this.$route.params.username;
+				if (/\s/.test(u)) {
+					u = `"${u}"`;
+				}
+				const within = this.$route.query.q ? " " + this.$route.query.q : "";
+				return "username:" + u + within;
+			}
+
 			if (!window.location.search) {
 				return false;
 			}

--- a/server/ui-src/mixins/MessagesMixins.js
+++ b/server/ui-src/mixins/MessagesMixins.js
@@ -54,6 +54,7 @@ export default {
 				mailbox.total = response.data.total; // all messages
 				mailbox.unread = response.data.unread; // all unread messages
 				mailbox.tags = response.data.tags; // all tags
+				mailbox.usernames = response.data.usernames; // all authentication usernames (mailboxes)
 				mailbox.messages = response.data.messages; // current messages
 				mailbox.count = response.data.messages_count; // total results for this mailbox/search
 				mailbox.messages_unread = response.data.messages_unread; // total unread results for this mailbox/search

--- a/server/ui-src/router/index.js
+++ b/server/ui-src/router/index.js
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from "vue-router";
+import MailboxUserView from "../views/MailboxUserView.vue";
 import MailboxView from "../views/MailboxView.vue";
 import MessageView from "../views/MessageView.vue";
 import NotFoundView from "../views/NotFoundView.vue";
@@ -21,6 +22,11 @@ const router = createRouter({
 		{
 			path: "/search",
 			component: SearchView,
+		},
+		{
+			path: "/mailbox/:username",
+			name: "mailbox",
+			component: MailboxUserView,
 		},
 		{
 			path: "/view/:id",

--- a/server/ui-src/stores/mailbox.js
+++ b/server/ui-src/stores/mailbox.js
@@ -24,9 +24,12 @@ export const mailbox = reactive({
 	count: 0, // total in mailbox or search
 	messages: [], // current messages
 	tags: [], // all tags
+	usernames: [], // all authentication usernames (mailboxes) in use
 	selected: [], // currently selected
 	connected: false, // websocket connection
 	searching: false, // current search, false for none
+	mailboxUser: "", // current dedicated username mailbox being viewed, "" for none
+	mailboxSearch: "", // active search/tag filter applied *within* the current username mailbox
 	refresh: false, // to listen from MessagesMixin
 	autoPaginating: true, // allows temporary bypass of loadMessages() via auto-pagination
 	notificationsSupported: false, // browser supports notifications

--- a/server/ui-src/views/MailboxUserView.vue
+++ b/server/ui-src/views/MailboxUserView.vue
@@ -34,51 +34,139 @@ export default {
 			mailbox,
 			pagination,
 			delayedRefresh: false,
+			paginationDelayed: false, // for delayed pagination URL changes
 		};
+	},
+
+	computed: {
+		username() {
+			return this.$route.params.username;
+		},
 	},
 
 	watch: {
 		$route() {
-			this.doSearch();
+			this.setupMailbox();
 		},
 	},
 
 	mounted() {
-		mailbox.searching = this.getSearch();
-		this.doSearch();
+		this.setupMailbox();
 
 		// subscribe to events
+		this.eventBus.on("new", this.handleWSNew);
 		this.eventBus.on("update", this.handleWSUpdate);
 		this.eventBus.on("delete", this.handleWSDelete);
 		this.eventBus.on("truncate", this.handleWSTruncate);
 	},
 
 	unmounted() {
+		// note: mailbox.mailboxUser is intentionally NOT cleared here so that
+		// opening a message and returning navigates back to this mailbox. It is
+		// reset when the Inbox or Search views are entered.
+
 		// unsubscribe from events
+		this.eventBus.off("new", this.handleWSNew);
 		this.eventBus.off("update", this.handleWSUpdate);
 		this.eventBus.off("delete", this.handleWSDelete);
 		this.eventBus.off("truncate", this.handleWSTruncate);
 	},
 
 	methods: {
-		doSearch() {
-			const s = this.getSearch();
+		// build the (search-backed) API URI to fetch only this mailbox's messages,
+		// composed with any within-mailbox tag/search filter (?q=)
+		setupMailbox() {
+			mailbox.searching = false;
+			mailbox.mailboxUser = this.username;
 
-			if (!s) {
-				mailbox.searching = false;
-				this.$router.push("/");
+			const within = this.$route.query.q ? this.$route.query.q.trim() : "";
+			mailbox.mailboxSearch = within;
+
+			const scope = "username:" + (/\s/.test(this.username) ? `"${this.username}"` : this.username);
+			const q = within ? scope + " " + within : scope;
+			this.apiURI = this.resolve(`/api/v1/search`) + "?query=" + encodeURIComponent(q);
+			if (mailbox.timeZone !== "" && (within.indexOf("after:") !== -1 || within.indexOf("before:") !== -1)) {
+				this.apiURI += "&tz=" + encodeURIComponent(mailbox.timeZone);
+			}
+
+			this.loadMailbox();
+		},
+
+		loadMailbox() {
+			const paginationParams = this.getPaginationParams();
+			if (paginationParams?.start) {
+				pagination.start = paginationParams.start;
+			} else {
+				pagination.start = 0;
+			}
+			if (paginationParams?.limit) {
+				pagination.limit = paginationParams.limit;
+			}
+
+			this.loadMessages();
+		},
+
+		// This will only update the pagination offset at a maximum of 2x per second
+		// when viewing the mailbox on > page 1, while receiving an influx of new messages.
+		delayedPaginationUpdate() {
+			if (this.paginationDelayed) {
 				return;
 			}
 
-			mailbox.searching = s;
-			mailbox.mailboxUser = "";
-			mailbox.mailboxSearch = "";
+			this.paginationDelayed = true;
 
-			this.apiURI = this.resolve(`/api/v1/search`) + "?query=" + encodeURIComponent(s);
-			if (mailbox.timeZone !== "" && (s.indexOf("after:") !== -1 || s.indexOf("before:") !== -1)) {
-				this.apiURI += "&tz=" + encodeURIComponent(mailbox.timeZone);
+			window.setTimeout(() => {
+				const path = this.$route.path;
+				const p = {
+					...this.$route.query,
+				};
+				if (pagination.start > 0) {
+					p.start = pagination.start.toString();
+				} else {
+					delete p.start;
+				}
+				if (pagination.limit !== pagination.defaultLimit) {
+					p.limit = pagination.limit.toString();
+				} else {
+					delete p.limit;
+				}
+
+				mailbox.autoPaginating = false; // prevent reload of messages when URL changes
+				const params = new URLSearchParams(p);
+				const qs = params.toString();
+				this.$router.replace(path + (qs ? "?" + qs : ""));
+
+				this.paginationDelayed = false;
+			}, 500);
+		},
+
+		// handler for websocket new messages
+		handleWSNew(data) {
+			// only messages authenticated as this mailbox's username belong here
+			if (data.Username !== this.username) {
+				return;
 			}
-			this.loadMessages();
+
+			// when a tag/search filter is applied within the mailbox we cannot
+			// reliably tell client-side whether a new message matches it, so skip
+			// live-prepending (consistent with the search view) and let the next
+			// manual reload / navigation pick it up
+			if (mailbox.mailboxSearch) {
+				return;
+			}
+
+			if (pagination.start < 1) {
+				// push results directly into first page
+				mailbox.messages.unshift(data);
+				if (mailbox.messages.length > pagination.limit) {
+					mailbox.messages.pop();
+				}
+			} else {
+				// update pagination offset
+				pagination.start++;
+				// prevent "Too many calls to Location or History APIs within a short time frame"
+				this.delayedPaginationUpdate();
+			}
 		},
 
 		// handler for websocket message updates
@@ -86,7 +174,10 @@ export default {
 			for (let x = 0; x < this.mailbox.messages.length; x++) {
 				if (this.mailbox.messages[x].ID === data.ID) {
 					// update message
-					this.mailbox.messages[x] = { ...this.mailbox.messages[x], ...data };
+					this.mailbox.messages[x] = {
+						...this.mailbox.messages[x],
+						...data,
+					};
 					return;
 				}
 			}
@@ -105,7 +196,8 @@ export default {
 			}
 
 			if (!removed || this.delayedRefresh) {
-				// nothing changed on this screen, or a refresh is queued, don't refresh
+				// nothing changed on this screen, or a refresh is queued,
+				// don't refresh
 				return;
 			}
 
@@ -120,8 +212,8 @@ export default {
 
 		// handler for websocket message truncation
 		handleWSTruncate() {
-			// all messages deleted, go back to inbox
-			this.$router.push("/");
+			// all messages gone, reload
+			this.loadMessages();
 		},
 	},
 };
@@ -136,9 +228,9 @@ export default {
 			</RouterLink>
 		</div>
 		<div class="col col-md-4k col-lg-5 col-xl-6">
-			<SearchForm @load-messages="loadMessages" />
+			<SearchForm />
 		</div>
-		<div class="col-12 col-md-auto col-lg-4 col-xl-4 text-end mt-2 mt-lg-0">
+		<div class="col-12 col-md-auto col-lg-4 col-xl-4 text-end mt-2 mt-md-0">
 			<div class="float-start d-md-none">
 				<button
 					class="btn btn-outline-light me-2"
@@ -194,6 +286,15 @@ export default {
 		</div>
 
 		<div class="col-xl-10 col-md-9 mh-100 ps-0 ps-md-2 pe-0">
+			<div class="d-flex align-items-center px-2 py-2 border-bottom small text-muted">
+				<i class="bi bi-inbox-fill me-2"></i>
+				<span>
+					Mailbox: <span class="fw-bold text-body">{{ username }}</span>
+					<template v-if="mailbox.mailboxSearch">
+						<span class="mx-1">·</span>filtered by <code>{{ mailbox.mailboxSearch }}</code>
+					</template>
+				</span>
+			</div>
 			<div id="message-page" class="mh-100" style="overflow-y: auto">
 				<ListMessages :loading-messages="loading" />
 			</div>

--- a/server/ui-src/views/MailboxView.vue
+++ b/server/ui-src/views/MailboxView.vue
@@ -6,6 +6,7 @@ import ListMessages from "../components/ListMessages.vue";
 import MessagesMixins from "../mixins/MessagesMixins";
 import NavMailbox from "../components/NavMailbox.vue";
 import NavTags from "../components/NavTags.vue";
+import NavUsernames from "../components/NavUsernames.vue";
 import Pagination from "../components/NavPagination.vue";
 import SearchForm from "../components/SearchForm.vue";
 import { mailbox } from "../stores/mailbox";
@@ -18,6 +19,7 @@ export default {
 		ListMessages,
 		NavMailbox,
 		NavTags,
+		NavUsernames,
 		Pagination,
 		SearchForm,
 	},
@@ -43,6 +45,8 @@ export default {
 
 	mounted() {
 		mailbox.searching = false;
+		mailbox.mailboxUser = "";
+		mailbox.mailboxSearch = "";
 		this.apiURI = this.resolve(`/api/v1/messages`);
 		this.loadMailbox();
 
@@ -223,6 +227,7 @@ export default {
 			<div class="d-flex flex-column h-100">
 				<div class="flex-grow-1 overflow-y-auto me-n3 pe-3">
 					<NavMailbox @load-messages="loadMessages" />
+					<NavUsernames />
 					<NavTags />
 				</div>
 				<About />
@@ -234,6 +239,7 @@ export default {
 		<div class="d-none d-md-flex h-100 col-xl-2 col-md-3 flex-column">
 			<div class="flex-grow-1 overflow-y-auto me-n3 pe-3">
 				<NavMailbox @load-messages="loadMessages" />
+				<NavUsernames />
 				<NavTags />
 			</div>
 			<About />

--- a/server/ui-src/views/MessageView.vue
+++ b/server/ui-src/views/MessageView.vue
@@ -222,8 +222,8 @@ export default {
 
 		// handler for websocket new messages
 		handleWSNew(data) {
-			// do not add when searching or >= 100 new messages have been received
-			if (this.mailbox.searching || this.liveLoaded >= 100) {
+			// do not add when searching, viewing a username mailbox, or >= 100 new messages have been received
+			if (this.mailbox.searching || this.mailbox.mailboxUser || this.liveLoaded >= 100) {
 				return;
 			}
 
@@ -327,7 +327,12 @@ export default {
 			let apiURI = this.resolve(`/api/v1/messages`);
 			const p = {};
 
-			if (mailbox.searching) {
+			if (mailbox.mailboxUser) {
+				apiURI = this.resolve(`/api/v1/search`);
+				const scope =
+					"username:" + (/\s/.test(mailbox.mailboxUser) ? `"${mailbox.mailboxUser}"` : mailbox.mailboxUser);
+				p.query = mailbox.mailboxSearch ? scope + " " + mailbox.mailboxSearch : scope;
+			} else if (mailbox.searching) {
 				apiURI = this.resolve(`/api/v1/search`);
 				p.query = mailbox.searching;
 			}
@@ -425,7 +430,20 @@ export default {
 		goBack() {
 			mailbox.lastMessage = this.$route.params.id;
 
-			if (mailbox.searching) {
+			if (mailbox.mailboxUser) {
+				const p = {};
+				if (mailbox.mailboxSearch) {
+					p.q = mailbox.mailboxSearch;
+				}
+				if (pagination.start > 0) {
+					p.start = pagination.start.toString();
+				}
+				if (pagination.limit !== pagination.defaultLimit) {
+					p.limit = pagination.limit.toString();
+				}
+				const qs = new URLSearchParams(p).toString();
+				this.$router.push("/mailbox/" + encodeURIComponent(mailbox.mailboxUser) + (qs ? "?" + qs : ""));
+			} else if (mailbox.searching) {
 				const p = {
 					q: mailbox.searching,
 				};
@@ -628,7 +646,8 @@ export default {
 					<i class="bi bi-arrow-return-left me-1"></i>
 					<span class="ms-1">
 						Return to
-						<template v-if="mailbox.searching">search</template>
+						<template v-if="mailbox.mailboxUser">{{ mailbox.mailboxUser }}</template>
+						<template v-else-if="mailbox.searching">search</template>
 						<template v-else>inbox</template>
 					</span>
 					<span

--- a/server/ui/api/v1/swagger.json
+++ b/server/ui/api/v1/swagger.json
@@ -1904,6 +1904,14 @@
           "type": "integer",
           "format": "uint64",
           "x-go-name": "Unread"
+        },
+        "usernames": {
+          "description": "All current authentication usernames (SMTP / Send API) in use",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Usernames"
         }
       },
       "x-go-package": "github.com/axllent/mailpit/server/apiv1"


### PR DESCRIPTION
## Summary

Adds **separate mailboxes**: when SMTP authentication is enabled, each authenticated
username can be viewed as its own switchable mailbox in the web UI. Mailpit already
records the authenticated username on every message — this surfaces it as a first-class,
filterable view, with **no database schema change**.

## Motivation

Several services can already share one Mailpit instance by authenticating with different
SMTP usernames, but there was no way to view mail grouped by service — everything landed
in one combined inbox. This lets you switch between per-service mailboxes.

## What's included

**Web UI**
- A **Mailbox** dropdown in the sidebar listing each authenticated username, plus `All mail`.
- A dedicated `/mailbox/<username>` route/view with a clean URL and an empty search bar.
- The selected mailbox acts as a persistent scope: [tags](https://mailpit.axllent.org/docs/usage/tagging/)
  and searches apply *within* the current mailbox; opening a message and returning keeps
  the mailbox; live updates are filtered to the mailbox.

**API / backend**
- New `username:<name>` search filter (exact match; supports `-username:` exclusion),
  composable with existing filters (`tag:`, `subject:`, …).
- `usernames` array added to the `/api/v1/messages` and `/api/v1/search` responses
  (additive, mirrors `tags`); `swagger.json` updated.
- `GET /mailbox/{username}` serves the SPA so direct loads / reloads work.

## No breaking changes

- Purely additive — the mailbox UI only appears once authenticated mail has been received.
- No schema change: reads the `Username` already stored in message metadata.
- Independent of `--tags-username` (username auto-tagging); the two can be used together.

## Testing

- New Go tests: `TestUsernameSearch` and `TestGetAllUsernames` (run across all tenant modes).
- `gofmt -s`, `go vet`, the Go test suite, and `npm run lint` (eslint + prettier) all pass.
- Manually verified end-to-end: multiple SMTP users, switching mailboxes, tag/search
  composition within a mailbox, live updates, and message back-navigation.

## Docs

Companion documentation PR: [axllent/mailpit-website#26](https://github.com/axllent/mailpit-website/pull/26)